### PR TITLE
Handle building tasks without inputs and input parameters which are JSON objects

### DIFF
--- a/src/ConductorSharp.Engine/Util/ExpressionUtil.cs
+++ b/src/ConductorSharp.Engine/Util/ExpressionUtil.cs
@@ -96,7 +96,7 @@ namespace ConductorSharp.Engine.Util
                 return string.Format(formatString, expressionStrings);
             }
 
-            if (assignmentExpression is NewExpression)
+            if (assignmentExpression is NewExpression || assignmentExpression is MemberInitExpression)
                 return ParseToParameters(assignmentExpression);
 
             return CompileMemberOrNameExpressions(assignmentExpression);


### PR DESCRIPTION
This PR adds the following features:

- Allows us to specify empty task input

  e.g.
  
  `builder.AddTask(wf => wf.SimpleTask, new SimpleTaskInput)`
  or from c# 9
  `builder.AddTask(wf => wf.SimpleTask, new())`
  
  This did not worked because runtime has different expression types for
  `new SimpleTask() { }`
  and 
  `new SimpleTask()`

- Allows us to specify input parameters which are JSON objects

e.g.

  ```
  builder.AddTask(wf => wf.SimpleTask, new()
  {
    Param1 = new
    {
       Param = "param"
    },
    Param2 = new ParamType()
    {
       Param = "param"
    }
  }
  ```

We support both concrete types and anonymous types
