### PR TITLE
Normalize newlines to \n for serialized definitions during testing

### DIFF
--- a/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
@@ -1,4 +1,5 @@
 ﻿using ConductorSharp.Engine.Tests.Samples.Workflows;
+using ConductorSharp.Engine.Tests.Util;
 
 namespace ConductorSharp.Engine.Tests.Integration
 {
@@ -7,7 +8,7 @@ namespace ConductorSharp.Engine.Tests.Integration
         [Fact]
         public void BuilderReturnsCorrectDefinition()
         {
-            var definition = JsonConvert.SerializeObject(new SendCustomerNotification().GetDefinition(), Formatting.Indented);
+            var definition = SerializationUtil.SerializeObject(new SendCustomerNotification().GetDefinition());
             var expectedDefinition = EmbeddedFileHelper.GetLinesFromEmbeddedFile("~/Samples/Workflows/SendCustomerNotification.json");
 
             Assert.Equal(expectedDefinition, definition);

--- a/test/ConductorSharp.Engine.Tests/Unit/TaskDefinitionBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Unit/TaskDefinitionBuilderTests.cs
@@ -1,4 +1,5 @@
 ﻿using ConductorSharp.Engine.Tests.Samples.Workers;
+using ConductorSharp.Engine.Tests.Util;
 
 namespace ConductorSharp.Engine.Tests.Unit
 {
@@ -7,7 +8,7 @@ namespace ConductorSharp.Engine.Tests.Unit
         [Fact]
         public void ReturnsCorrectDefinition()
         {
-            var definition = JsonConvert.SerializeObject(TaskDefinitionBuilder.Build<GetCustomerHandler>(null), Formatting.Indented);
+            var definition = SerializationUtil.SerializeObject(TaskDefinitionBuilder.Build<GetCustomerHandler>(null));
             var expectedDefinition = EmbeddedFileHelper.GetLinesFromEmbeddedFile("~/Samples/Tasks/CustomerGet.json");
 
             Assert.Equal(expectedDefinition, definition);

--- a/test/ConductorSharp.Engine.Tests/Util/SerializationUtil.cs
+++ b/test/ConductorSharp.Engine.Tests/Util/SerializationUtil.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConductorSharp.Engine.Tests.Util
+{
+    internal static class SerializationUtil
+    {
+        public static string SerializeObject(object @object) => JsonConvert.SerializeObject(@object, Formatting.Indented).Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
On Windows JsonConvert.SerializeObject generates \r\n instead of \n. 
AFAIK there is no way to change this via configuration of serializer.