### PR TITLE
Read version attribute from subworkflow models

### DIFF
--- a/src/ConductorSharp.Engine/Builders/SubWorkflowTaskBuilder.cs
+++ b/src/ConductorSharp.Engine/Builders/SubWorkflowTaskBuilder.cs
@@ -1,13 +1,18 @@
 ﻿using ConductorSharp.Client.Model.Common;
+using ConductorSharp.Engine.Util;
 using MediatR;
 using Newtonsoft.Json.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace ConductorSharp.Engine.Builders
 {
     public class SubWorkflowTaskBuilder<TInput, TOutput> : BaseTaskBuilder<TInput, TOutput> where TInput : IRequest<TOutput>
     {
-        public SubWorkflowTaskBuilder(Expression taskExpression, Expression inputExpression) : base(taskExpression, inputExpression) { }
+        private readonly int _version;
+
+        public SubWorkflowTaskBuilder(Expression taskExpression, Expression inputExpression) : base(taskExpression, inputExpression) =>
+            _version = GetVersion(taskExpression);
 
         public override WorkflowDefinition.Task[] Build() =>
             new WorkflowDefinition.Task[]
@@ -18,10 +23,16 @@ namespace ConductorSharp.Engine.Builders
                     TaskReferenceName = _taskRefferenceName,
                     Type = "SUB_WORKFLOW",
                     InputParameters = _inputParameters,
-                    SubWorkflowParam = new WorkflowDefinition.SubWorkflowParam { Name = _taskName, Version = 1 },
+                    SubWorkflowParam = new WorkflowDefinition.SubWorkflowParam { Name = _taskName, Version = _version },
                     Description = new JObject { new JProperty("description", _description) }.ToString(Newtonsoft.Json.Formatting.None),
                     Optional = _additionalParameters?.Optional == true
                 }
             };
+
+        private int GetVersion(Expression taskExpression)
+        {
+            var type = ExpressionUtil.ParseToType(taskExpression);
+            return type.GetCustomAttribute<VersionAttribute>()?.Version ?? 1;
+        }
     }
 }

--- a/src/ConductorSharp.Engine/Util/VersionAttribute.cs
+++ b/src/ConductorSharp.Engine/Util/VersionAttribute.cs
@@ -5,7 +5,7 @@ namespace ConductorSharp.Engine.Util
     [AttributeUsage(AttributeTargets.Class)]
     public class VersionAttribute : Attribute
     {
-        public int Version { get; }
+        internal int Version { get; }
 
         public VersionAttribute(int version) => Version = version;
     }

--- a/src/ConductorSharp.Engine/Util/VersionAttribute.cs
+++ b/src/ConductorSharp.Engine/Util/VersionAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ConductorSharp.Engine.Util
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class VersionAttribute : Attribute
+    {
+        public int Version { get; }
+
+        public VersionAttribute(int version) => Version = version;
+    }
+}

--- a/src/ConductorSharp.Toolkit/Service/ScaffoldingService.cs
+++ b/src/ConductorSharp.Toolkit/Service/ScaffoldingService.cs
@@ -68,7 +68,8 @@ namespace ConductorSharp.Toolkit.Service
 
             var modelGenerator = new TaskModelGenerator(_config.BaseNamespace + ".Workflows", name, TaskModelGenerator.ModelType.Workflow)
             {
-                OriginalName = workflowDefinition.Name
+                OriginalName = workflowDefinition.Name,
+                Version = workflowDefinition.Version
             };
             string workflowDescription = workflowDefinition.Description;
             string[] labels;

--- a/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
+++ b/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -16,6 +16,7 @@
     <None Remove="Samples\Workflows\SendCustomerNotification.json" />
     <None Remove="Samples\Workflows\StringInterpolation.json" />
     <None Remove="Samples\Workflows\TerminateTaskWorkflow.json" />
+    <None Remove="Samples\Workflows\VersionAttributeWorkflow.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,6 +28,7 @@
 	<EmbeddedResource Include="Samples\Workflows\SendCustomerNotification.json" />
 	<EmbeddedResource Include="Samples\Workflows\StringInterpolation.json" />
 	<EmbeddedResource Include="Samples\Workflows\TerminateTaskWorkflow.json" />
+	<EmbeddedResource Include="Samples\Workflows\VersionAttributeWorkflow.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
@@ -78,5 +78,14 @@ namespace ConductorSharp.Engine.Tests.Integration
 
             Assert.Equal(expectedDefinition, definition);
         }
+
+        [Fact]
+        public void BuilderReturnsCorrectDefinitionSubworkflowVersionAttribute()
+        {
+            var definition = SerializationUtil.SerializeObject(new VersionAttributeWorkflow().GetDefinition());
+            var expectedDefinition = EmbeddedFileHelper.GetLinesFromEmbeddedFile("~/Samples/Workflows/VersionAttributeWorkflow.json");
+
+            Assert.Equal(expectedDefinition, definition);
+        }
     }
 }

--- a/test/ConductorSharp.Engine.Tests/Samples/Tasks/VersionSubworkflow.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Tasks/VersionSubworkflow.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConductorSharp.Engine.Tests.Samples.Tasks
+{
+    public class VersionSubworkflowInput : IRequest<VersionSubworkflowOutput> { }
+
+    public class VersionSubworkflowOutput { }
+
+    [OriginalName("TEST_subworkflow")]
+    [Version(3)]
+    public class VersionSubworkflow : SubWorkflowTaskModel<VersionSubworkflowInput, VersionSubworkflowOutput> { }
+}

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/VersionAttributeWorkflow.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/VersionAttributeWorkflow.cs
@@ -1,0 +1,20 @@
+﻿namespace ConductorSharp.Engine.Tests.Samples.Workflows
+{
+    public class VersionAttributeWorkflowInput : WorkflowInput<VersionAttributeWorkflowOutput> { }
+
+    public class VersionAttributeWorkflowOutput : WorkflowOutput { }
+
+    public class VersionAttributeWorkflow : Workflow<VersionAttributeWorkflowInput, VersionAttributeWorkflowOutput>
+    {
+        public VersionSubworkflow TestSubworkflow { get; set; }
+
+        public override WorkflowDefinition GetDefinition()
+        {
+            var builder = new WorkflowDefinitionBuilder<VersionAttributeWorkflow>();
+
+            builder.AddTask(wf => wf.TestSubworkflow, wf => new());
+
+            return builder.Build(opts => opts.Version = 1);
+        }
+    }
+}

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/VersionAttributeWorkflow.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/VersionAttributeWorkflow.json
@@ -1,0 +1,60 @@
+{
+  "ownerApp": null,
+  "createTime": 0,
+  "updateTime": 0,
+  "createdBy": null,
+  "updatedBy": null,
+  "name": "version_attribute_workflow",
+  "description": "{\"description\":null,\"labels\":null}",
+  "version": 1,
+  "tasks": [
+    {
+      "queryExpression": null,
+      "name": "TEST_subworkflow",
+      "taskReferenceName": "test_subworkflow",
+      "description": "{\"description\":null}",
+      "inputParameters": {},
+      "type": "SUB_WORKFLOW",
+      "dynamicTaskNameParam": null,
+      "caseValueParam": null,
+      "caseExpression": null,
+      "expression": null,
+      "evaluatorType": null,
+      "scriptExpression": null,
+      "decisionCases": null,
+      "dynamicForkJoinTasksParam": null,
+      "dynamicForkTasksParam": null,
+      "dynamicForkTasksInputParamName": null,
+      "defaultCase": null,
+      "forkTasks": null,
+      "startDelay": 0,
+      "subWorkflowParam": {
+        "name": "TEST_subworkflow",
+        "version": 3,
+        "taskToDomain": null,
+        "workflowDefinition": null
+      },
+      "joinOn": null,
+      "sink": null,
+      "optional": false,
+      "taskDefinition": null,
+      "rateLimited": false,
+      "defaultExclusiveJoinTask": null,
+      "asyncComplete": false,
+      "loopCondition": null,
+      "loopOver": null
+    }
+  ],
+  "inputParameters": [
+    "{}"
+  ],
+  "outputParameters": null,
+  "failureWorkflow": null,
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": true,
+  "ownerEmail": null,
+  "timeoutPolicy": null,
+  "timeoutSeconds": 0,
+  "variables": null
+}


### PR DESCRIPTION
The workflow version was hard coded to 1 when specifying sub-workflow. 
The solution was to add a Version attribute which is checked during workflow build.