### PR TITLE
Add error message to output

### DIFF
--- a/src/ConductorSharp.Client/Service/ITaskService.cs
+++ b/src/ConductorSharp.Client/Service/ITaskService.cs
@@ -17,6 +17,7 @@ namespace ConductorSharp.Client.Service
         Task UpdateTaskCompleted(object outputData, string taskId, string workflowId);
         Task UpdateTaskFailed(string taskId, string workflowId, string reasonForIncompletion);
         Task UpdateTaskFailed(string taskId, string workflowId, string reasonForIncompletion, string logMessage);
+        Task UpdateTaskFailed(object outputData, string taskId, string workflowId, string reasonForIncompletion, string logMessage);
         Task<PollTaskResponse> PollTasks(string name, string workerId);
         Task<PollTaskResponse> PollTasks(string name, string workerId, string domain);
         Task<GetTaskLogsResponse[]> GetLogsForTask(string taskId);

--- a/src/ConductorSharp.Client/Service/TaskService.cs
+++ b/src/ConductorSharp.Client/Service/TaskService.cs
@@ -97,5 +97,22 @@ namespace ConductorSharp.Client.Service
 
         public Task<GetTaskLogsResponse[]> GetLogsForTask(string taskId) =>
             _client.ExecuteRequestAsync<GetTaskLogsResponse[]>(ApiUrls.GetLogsForTask(taskId), HttpMethod.Get);
+
+        public Task UpdateTaskFailed(object outputData, string taskId, string workflowId, string reasonForIncompletion, string logMessage) =>
+            UpdateTask(
+                new UpdateTaskRequest
+                {
+                    Status = "FAILED",
+                    TaskId = taskId,
+                    OutputData = JObject.FromObject(outputData, ConductorConstants.IoJsonSerializer),
+                    WorkflowInstanceId = workflowId,
+                    ReasonForIncompletion = reasonForIncompletion,
+                    Logs = new List<LogData>
+                    {
+                        new LogData { Log = reasonForIncompletion, CreatedTime = DateTimeOffset.Now.ToUnixTimeMilliseconds() },
+                        new LogData { Log = logMessage, CreatedTime = DateTimeOffset.Now.ToUnixTimeMilliseconds() }
+                    }
+                }
+            );
     }
 }

--- a/src/ConductorSharp.Engine/ExecutionManager.cs
+++ b/src/ConductorSharp.Engine/ExecutionManager.cs
@@ -111,7 +111,16 @@ namespace ConductorSharp.Engine
                     pollResponse.WorkflowType,
                     pollResponse.WorkflowInstanceId
                 );
-                await _taskManager.UpdateTaskFailed(pollResponse.TaskId, pollResponse.WorkflowInstanceId, exception.Message, exception.StackTrace);
+
+                var errorMessage = new ErrorOutput { ErrorMessage = exception.Message };
+
+                await _taskManager.UpdateTaskFailed(
+                    errorMessage,
+                    pollResponse.TaskId,
+                    pollResponse.WorkflowInstanceId,
+                    exception.Message,
+                    exception.StackTrace
+                );
             }
         }
     }

--- a/src/ConductorSharp.Engine/Model/ErrorOutput.cs
+++ b/src/ConductorSharp.Engine/Model/ErrorOutput.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ConductorSharp.Engine.Model
+{
+    public class ErrorOutput
+    {
+        public string ErrorMessage { get; set; }
+    }
+}


### PR DESCRIPTION
This adds an "error_message" field to the output of failed tasks. It changes the default behavior so it is a significant change. However, it should not affect anybody using the library as it is an addition where previously nothing was found.