### PR TITLE
Allow workflow and worker referencing with builder

### DIFF
--- a/src/ConductorSharp.Client/ConductorSharp.Client.csproj
+++ b/src/ConductorSharp.Client/ConductorSharp.Client.csproj
@@ -6,7 +6,7 @@
 		<Authors>Codaxy</Authors>
 		<Company>Codaxy</Company>
 		<PackageId>ConductorSharp.Client</PackageId>
-		<Version>1.4.0</Version>
+		<Version>1.5.0-alpha1</Version>
 		<Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 		<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 		<PackageTags>netflix;conductor</PackageTags>

--- a/src/ConductorSharp.Engine/Builders/TaskDefinitionBuilder.cs
+++ b/src/ConductorSharp.Engine/Builders/TaskDefinitionBuilder.cs
@@ -20,7 +20,10 @@ namespace ConductorSharp.Engine.Builders
 
             XmlDocumentationReader.LoadXmlDocumentation(taskType.Assembly);
 
-            var interfaces = taskType.GetInterfaces().Where(a => a.GetGenericTypeDefinition() == typeof(ITaskRequestHandler<,>)).First();
+            var interfaces = taskType
+                .GetInterfaces()
+                .Where(a => a.IsGenericType && a.GetGenericTypeDefinition() == typeof(ITaskRequestHandler<,>))
+                .First();
             var genericArguments = interfaces.GetGenericArguments();
 
             var inputType = genericArguments[0];

--- a/src/ConductorSharp.Engine/Builders/Workflow.cs
+++ b/src/ConductorSharp.Engine/Builders/Workflow.cs
@@ -1,9 +1,11 @@
 ﻿using ConductorSharp.Client.Model.Common;
 using ConductorSharp.Engine.Interface;
+using ConductorSharp.Engine.Model;
+using MediatR;
 
 namespace ConductorSharp.Engine.Builders
 {
-    public class WorkflowInput<T> : IWorkflowInput where T : WorkflowOutput { }
+    public class WorkflowInput<T> : IWorkflowInput, IRequest<T> where T : WorkflowOutput { }
 
     public class WorkflowOutput { }
 
@@ -11,7 +13,7 @@ namespace ConductorSharp.Engine.Builders
 
     public interface IWorkflowInput { }
 
-    public abstract class Workflow<TInput, TOutput> : ITypedWorkflow
+    public abstract class Workflow<TInput, TOutput> : SubWorkflowTaskModel<TInput, TOutput>, ITypedWorkflow
         where TInput : WorkflowInput<TOutput>
         where TOutput : WorkflowOutput
     {

--- a/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
+++ b/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
@@ -6,7 +6,7 @@
     <Authors>Codaxy</Authors>
 	<Company>Codaxy</Company>
 	<PackageId>ConductorSharp.Engine</PackageId>
-	<Version>1.4.0</Version>
+	<Version>1.5.0-alpha1</Version>
     <Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 	<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 	<PackageTags>netflix;conductor</PackageTags>

--- a/src/ConductorSharp.Engine/TaskRequestHandler.cs
+++ b/src/ConductorSharp.Engine/TaskRequestHandler.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace ConductorSharp.Engine.Util
+namespace ConductorSharp.Engine
 {
     public abstract class TaskRequestHandler<TInput, TOutput> : SimpleTaskModel<TInput, TOutput>, ITaskRequestHandler<TInput, TOutput>
         where TInput : IRequest<TOutput>

--- a/src/ConductorSharp.Engine/TaskRequestHandler.cs
+++ b/src/ConductorSharp.Engine/TaskRequestHandler.cs
@@ -1,0 +1,17 @@
+﻿using ConductorSharp.Engine.Interface;
+using ConductorSharp.Engine.Model;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ConductorSharp.Engine
+{
+    public abstract class TaskRequestHandler<TInput, TOutput> : SimpleTaskModel<TInput, TOutput>, ITaskRequestHandler<TInput, TOutput>
+        where TInput : IRequest<TOutput>
+    {
+        public abstract Task<TOutput> Handle(TInput request, CancellationToken cancellationToken);
+    }
+}

--- a/src/ConductorSharp.Engine/Util/TaskRequestHandler.cs
+++ b/src/ConductorSharp.Engine/Util/TaskRequestHandler.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace ConductorSharp.Engine
+namespace ConductorSharp.Engine.Util
 {
     public abstract class TaskRequestHandler<TInput, TOutput> : SimpleTaskModel<TInput, TOutput>, ITaskRequestHandler<TInput, TOutput>
         where TInput : IRequest<TOutput>

--- a/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
+++ b/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
@@ -14,6 +14,7 @@
     <None Remove="Samples\Workflows\DecisionInDecision.json" />
     <None Remove="Samples\Workflows\NestedObjects.json" />
     <None Remove="Samples\Workflows\OptionalTaskWorkflow.json" />
+    <None Remove="Samples\Workflows\ScaffoldedWorkflows.json" />
     <None Remove="Samples\Workflows\SendCustomerNotification.json" />
     <None Remove="Samples\Workflows\StringInterpolation.json" />
     <None Remove="Samples\Workflows\TerminateTaskWorkflow.json" />
@@ -28,6 +29,7 @@
     <EmbeddedResource Include="Samples\Tasks\CustomerGet.json" />
     <EmbeddedResource Include="Samples\Tasks\EmailPrepare.json" />
     <EmbeddedResource Include="Samples\Workflows\Arrays.json" />
+    <EmbeddedResource Include="Samples\Workflows\ScaffoldedWorkflows.json" />
     <EmbeddedResource Include="Samples\Workflows\OptionalTaskWorkflow.json" />
     <EmbeddedResource Include="Samples\Workflows\NestedObjects.json" />
 	<EmbeddedResource Include="Samples\Workflows\SendCustomerNotification.json" />

--- a/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
@@ -88,6 +88,15 @@ namespace ConductorSharp.Engine.Tests.Integration
             Assert.Equal(expectedDefinition, definition);
         }
 
+        [Fact]
+        public void BuilderReturnsCorrectDefinitionSubWorkflowModelsOnly()
+        {
+            var definition = SerializationUtil.SerializeObject(new ScaffoldedWorkflows().GetDefinition());
+            var expectedDefinition = EmbeddedFileHelper.GetLinesFromEmbeddedFile("~/Samples/Workflows/ScaffoldedWorkflows.json");
+
+            Assert.Equal(expectedDefinition, definition);
+        }
+
         public void BuilderReturnsCorrectDefinitionSubworkflowVersionAttribute()
         {
             var definition = SerializationUtil.SerializeObject(new VersionAttributeWorkflow().GetDefinition());

--- a/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
@@ -97,6 +97,7 @@ namespace ConductorSharp.Engine.Tests.Integration
             Assert.Equal(expectedDefinition, definition);
         }
 
+        [Fact]
         public void BuilderReturnsCorrectDefinitionSubworkflowVersionAttribute()
         {
             var definition = SerializationUtil.SerializeObject(new VersionAttributeWorkflow().GetDefinition());

--- a/test/ConductorSharp.Engine.Tests/Samples/Workers/GetCustomerHandler.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workers/GetCustomerHandler.cs
@@ -22,7 +22,8 @@ public class Customer
 }
 
 [OriginalName("CUSTOMER_get")]
-public class GetCustomerHandler : ITaskRequestHandler<GetCustomerRequest, GetCustomerResponse>
+public class GetCustomerHandler : TaskRequestHandler<GetCustomerRequest, GetCustomerResponse>
 {
-    public Task<GetCustomerResponse> Handle(GetCustomerRequest request, CancellationToken cancellationToken) => throw new NotImplementedException();
+    public override Task<GetCustomerResponse> Handle(GetCustomerRequest request, CancellationToken cancellationToken) =>
+        throw new NotImplementedException();
 }

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/ConditionallySendCustomerNotificationOutput.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/ConditionallySendCustomerNotificationOutput.cs
@@ -13,7 +13,7 @@ public class ConditionallySendCustomerNotificationOutput : WorkflowOutput { }
 public class ConditionallySendCustomerNotification : Workflow<ConditionallySendCustomerNotificationInput, ConditionallySendCustomerNotificationOutput>
 {
     public DecisionTaskModel SendNotificationDecision { get; set; }
-    public SendCustomerNotificationV1 SendNotificationSubworkflow { get; set; }
+    public SendCustomerNotification SendNotificationSubworkflow { get; set; }
 
     public override WorkflowDefinition GetDefinition()
     {

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/ConditionallySendCustomerNotificationOutput.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/ConditionallySendCustomerNotificationOutput.cs
@@ -3,8 +3,8 @@
 #region models
 public class ConditionallySendCustomerNotificationInput : WorkflowInput<ConditionallySendCustomerNotificationOutput>
 {
-    public dynamic ShouldSendNotification { get; set; }
-    public dynamic CustomerId { get; set; }
+    public bool ShouldSendNotification { get; set; }
+    public int CustomerId { get; set; }
 }
 
 public class ConditionallySendCustomerNotificationOutput : WorkflowOutput { }

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/DecisionInDecision.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/DecisionInDecision.cs
@@ -19,7 +19,7 @@ namespace ConductorSharp.Engine.Tests.Samples.Workflows
     {
         public DecisionTaskModel SendNotificationDecision { get; set; }
         public DecisionTaskModel SecondSendNotificationDecision { get; set; }
-        public SendCustomerNotificationV1 SendNotificationSubworkflow { get; set; }
+        public SendCustomerNotification SendNotificationSubworkflow { get; set; }
 
         public override WorkflowDefinition GetDefinition()
         {

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/DecisionInDecision.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/DecisionInDecision.cs
@@ -8,8 +8,8 @@ namespace ConductorSharp.Engine.Tests.Samples.Workflows
 {
     public class DecisionInDecisionInput : WorkflowInput<DecisionInDecisionOutput>
     {
-        public dynamic ShouldSendNotification { get; set; }
-        public dynamic CustomerId { get; set; }
+        public bool ShouldSendNotification { get; set; }
+        public int CustomerId { get; set; }
     }
 
     public class DecisionInDecisionOutput : WorkflowOutput { }

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/OptionalTaskWorkflow.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/OptionalTaskWorkflow.cs
@@ -8,7 +8,7 @@ namespace ConductorSharp.Engine.Tests.Samples.Workflows
 {
     public class OptionalTaskWorkflowInput : WorkflowInput<OptionalTaskWorkflowOutput>
     {
-        public dynamic CustomerId { get; set; }
+        public int CustomerId { get; set; }
     }
 
     public class OptionalTaskWorkflowOutput : WorkflowOutput { }

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/OptionalTaskWorkflow.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/OptionalTaskWorkflow.cs
@@ -16,7 +16,7 @@ namespace ConductorSharp.Engine.Tests.Samples.Workflows
     [OriginalName("TEST_optional_task_workflow")]
     public class OptionalTaskWorkflow : Workflow<OptionalTaskWorkflowInput, OptionalTaskWorkflowOutput>
     {
-        public SendCustomerNotificationV1 SendNotificationSubworkflow { get; set; }
+        public SendCustomerNotification SendNotificationSubworkflow { get; set; }
 
         public override WorkflowDefinition GetDefinition()
         {

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/ScaffoldedWorkflows.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/ScaffoldedWorkflows.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConductorSharp.Engine.Tests.Samples.Workflows
+{
+    #region s_one
+    public class ScaffoldedOneInput : WorkflowInput<ScaffoldedOneOutput>
+    {
+        public dynamic InputOne { get; set; }
+    }
+
+    public class ScaffoldedOneOutput : WorkflowOutput
+    {
+        public dynamic OutputOne { get; set; }
+    }
+
+    [OriginalName("SCAFFOLDED_one")]
+    public class ScaffoldedOne : SubWorkflowTaskModel<ScaffoldedOneInput, ScaffoldedOneOutput> { }
+    #endregion
+    #region s_two
+    public class ScaffoldedTwoInput : WorkflowInput<ScaffoldedTwoOutput>
+    {
+        public dynamic Name { get; set; }
+    }
+
+    public class ScaffoldedTwoOutput : WorkflowOutput
+    {
+        public dynamic OutputName { get; set; }
+    }
+
+    [OriginalName("SCAFFOLDED_two")]
+    public class ScaffoldedTwo : SubWorkflowTaskModel<ScaffoldedTwoInput, ScaffoldedTwoOutput> { }
+    #endregion
+    public class ScaffoldedWorkflowsInput : WorkflowInput<ScaffoldedWorkflowsOutput>
+    {
+        public int CustomerId { get; set; }
+    }
+
+    public class ScaffoldedWorkflowsOutput : WorkflowOutput { }
+
+    [OriginalName("SCAFFOLDED_workflows")]
+    public class ScaffoldedWorkflows : Workflow<ScaffoldedWorkflowsInput, ScaffoldedWorkflowsOutput>
+    {
+        public ScaffoldedOne ScaffOne { get; set; }
+        public ScaffoldedTwo ScaffTwo { get; set; }
+
+        public override WorkflowDefinition GetDefinition()
+        {
+            var builder = new WorkflowDefinitionBuilder<ScaffoldedWorkflows>();
+
+            builder.AddTask(wf => wf.ScaffOne, wf => new() { InputOne = wf.WorkflowInput.CustomerId });
+
+            builder.AddTask(wf => wf.ScaffTwo, wf => new() { Name = wf.ScaffOne.Output.OutputOne });
+
+            return builder.Build(opts => opts.Version = 1);
+        }
+    }
+}

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/ScaffoldedWorkflows.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/ScaffoldedWorkflows.json
@@ -1,0 +1,100 @@
+{
+  "ownerApp": null,
+  "createTime": 0,
+  "updateTime": 0,
+  "createdBy": null,
+  "updatedBy": null,
+  "name": "SCAFFOLDED_workflows",
+  "description": "{\"description\":null,\"labels\":null}",
+  "version": 1,
+  "tasks": [
+    {
+      "queryExpression": null,
+      "name": "SCAFFOLDED_one",
+      "taskReferenceName": "scaff_one",
+      "description": "{\"description\":null}",
+      "inputParameters": {
+        "input_one": "${workflow.input.customer_id}"
+      },
+      "type": "SUB_WORKFLOW",
+      "dynamicTaskNameParam": null,
+      "caseValueParam": null,
+      "caseExpression": null,
+      "expression": null,
+      "evaluatorType": null,
+      "scriptExpression": null,
+      "decisionCases": null,
+      "dynamicForkJoinTasksParam": null,
+      "dynamicForkTasksParam": null,
+      "dynamicForkTasksInputParamName": null,
+      "defaultCase": null,
+      "forkTasks": null,
+      "startDelay": 0,
+      "subWorkflowParam": {
+        "name": "SCAFFOLDED_one",
+        "version": 1,
+        "taskToDomain": null,
+        "workflowDefinition": null
+      },
+      "joinOn": null,
+      "sink": null,
+      "optional": false,
+      "taskDefinition": null,
+      "rateLimited": false,
+      "defaultExclusiveJoinTask": null,
+      "asyncComplete": false,
+      "loopCondition": null,
+      "loopOver": null
+    },
+    {
+      "queryExpression": null,
+      "name": "SCAFFOLDED_two",
+      "taskReferenceName": "scaff_two",
+      "description": "{\"description\":null}",
+      "inputParameters": {
+        "name": "${scaff_one.output.output_one}"
+      },
+      "type": "SUB_WORKFLOW",
+      "dynamicTaskNameParam": null,
+      "caseValueParam": null,
+      "caseExpression": null,
+      "expression": null,
+      "evaluatorType": null,
+      "scriptExpression": null,
+      "decisionCases": null,
+      "dynamicForkJoinTasksParam": null,
+      "dynamicForkTasksParam": null,
+      "dynamicForkTasksInputParamName": null,
+      "defaultCase": null,
+      "forkTasks": null,
+      "startDelay": 0,
+      "subWorkflowParam": {
+        "name": "SCAFFOLDED_two",
+        "version": 1,
+        "taskToDomain": null,
+        "workflowDefinition": null
+      },
+      "joinOn": null,
+      "sink": null,
+      "optional": false,
+      "taskDefinition": null,
+      "rateLimited": false,
+      "defaultExclusiveJoinTask": null,
+      "asyncComplete": false,
+      "loopCondition": null,
+      "loopOver": null
+    }
+  ],
+  "inputParameters": [
+    "{\"customer_id\":{\"value\":\"\",\"description\":\" (optional)\"}}"
+  ],
+  "outputParameters": null,
+  "failureWorkflow": null,
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": true,
+  "ownerEmail": null,
+  "timeoutPolicy": null,
+  "timeoutSeconds": 0,
+  "variables": null
+}

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/SendCustomerNotification.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/SendCustomerNotification.cs
@@ -1,9 +1,11 @@
-﻿namespace ConductorSharp.Engine.Tests.Samples.Workflows;
+﻿using ConductorSharp.Engine.Tests.Samples.Workers;
+
+namespace ConductorSharp.Engine.Tests.Samples.Workflows;
 
 #region models
 public class SendCustomerNotificationInput : WorkflowInput<SendCustomerNotificationOutput>
 {
-    public dynamic CustomerId { get; set; }
+    public int CustomerId { get; set; }
 }
 
 public class SendCustomerNotificationOutput : WorkflowOutput
@@ -14,7 +16,7 @@ public class SendCustomerNotificationOutput : WorkflowOutput
 [OriginalName("NOTIFICATION_send_to_customer")]
 public class SendCustomerNotification : Workflow<SendCustomerNotificationInput, SendCustomerNotificationOutput>
 {
-    public CustomerGetV1 GetCustomer { get; set; }
+    public GetCustomerHandler GetCustomer { get; set; }
     public EmailPrepareV1 PrepareEmail { get; set; }
 
     public override WorkflowDefinition GetDefinition()

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/SendCustomerNotification.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/SendCustomerNotification.cs
@@ -1,16 +1,6 @@
 ﻿namespace ConductorSharp.Engine.Tests.Samples.Workflows;
 
 #region models
-public class SendNotificationInput : IRequest<SendNotificationOutput>
-{
-    public dynamic CustomerId { get; set; }
-}
-
-public class SendNotificationOutput { }
-
-[OriginalName("NOTIFICATION_send_to_customer")]
-public class SendCustomerNotificationV1 : SubWorkflowTaskModel<SendNotificationInput, SendNotificationOutput> { }
-
 public class SendCustomerNotificationInput : WorkflowInput<SendCustomerNotificationOutput>
 {
     public dynamic CustomerId { get; set; }


### PR DESCRIPTION
This PR adds the capability to directly reference classes that inherrit `Workflow` and `TaskRequestHandler` in workflow definitions. This should reduce the amount of classes that we have to write in the following ways:

- We no longer have to write a `SubWorkflowTaskModel` class for workflows we created ourselves just to be able to reference it in other workflows as a subworkflow. 
- We no longer have to write a `SimpleTaskModel` class if we access to the worker class that inherits `TaskRequestHandler` (this is a new addition, a sort of base class that implements `ITaskRequestHandler`). This case should not really happen as we recommend that workflow definitions are kept separate from workers, but it could help some users.