### PR TITLE
Exit background on fail

### DIFF
--- a/examples/ConductorSharp.Definitions/appsettings.json
+++ b/examples/ConductorSharp.Definitions/appsettings.json
@@ -5,6 +5,6 @@
     "LongPollInterval": 100,
     "MaxConcurrentWorkers": 10,
     "SleepInterval": 500,
-    "PreventErrorOnBadRequest": false
+    "PreventErrorOnBadRequest": true
   }
 }

--- a/examples/ConductorSharp.Definitions/appsettings.json
+++ b/examples/ConductorSharp.Definitions/appsettings.json
@@ -5,6 +5,6 @@
     "LongPollInterval": 100,
     "MaxConcurrentWorkers": 10,
     "SleepInterval": 500,
-    "PreventErrorOnBadRequest": true
+    "PreventErrorOnBadRequest": false
   }
 }

--- a/src/ConductorSharp.Engine/Service/WorkflowEngineBackgroundService.cs
+++ b/src/ConductorSharp.Engine/Service/WorkflowEngineBackgroundService.cs
@@ -14,7 +14,6 @@ namespace ConductorSharp.Engine.Service
         private readonly IDeploymentService _deploymentService;
         private readonly ExecutionManager _executionManager;
         private readonly ModuleDeployment _deployment;
-        private Task _executingTask;
 
         public WorkflowEngineBackgroundService(
             ILogger<WorkflowEngineBackgroundService> logger,

--- a/src/ConductorSharp.Engine/Service/WorkflowEngineBackgroundService.cs
+++ b/src/ConductorSharp.Engine/Service/WorkflowEngineBackgroundService.cs
@@ -14,6 +14,7 @@ namespace ConductorSharp.Engine.Service
         private readonly IDeploymentService _deploymentService;
         private readonly ExecutionManager _executionManager;
         private readonly ModuleDeployment _deployment;
+        private Task _executingTask;
 
         public WorkflowEngineBackgroundService(
             ILogger<WorkflowEngineBackgroundService> logger,

--- a/src/ConductorSharp.Engine/Service/WorkflowEngineBackgroundService.cs
+++ b/src/ConductorSharp.Engine/Service/WorkflowEngineBackgroundService.cs
@@ -55,6 +55,10 @@ namespace ConductorSharp.Engine.Service
             }
         }
 
-        public async Task StopAsync(CancellationToken cancellationToken) => await _executingTask;
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogDebug("Stopping Workflow Engine Background Service");
+            return Task.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
This PR makes the background service terminate the host application on error. It also fixes the incorrect usage of cancellation tokens. Previously we only cancelled if the start token was cancelled.

The implementation is more in line with how https://github.com/aspnet/Hosting/blob/master/src/Microsoft.Extensions.Hosting.Abstractions/BackgroundService.cs works.