### PR TITLE
Add new way of specifying decision tasks

### DIFF
--- a/src/ConductorSharp.Engine/Builders/DecisionCases.cs
+++ b/src/ConductorSharp.Engine/Builders/DecisionCases.cs
@@ -1,0 +1,19 @@
+﻿using ConductorSharp.Engine.Interface;
+using System;
+using System.Collections.Generic;
+
+namespace ConductorSharp.Engine.Builders
+{
+    public class DecisionCases<TWorkflow> where TWorkflow : ITypedWorkflow
+    {
+        private readonly Dictionary<string, Action<DecisionTaskBuilder<TWorkflow>>> _cases = new();
+        public Action<DecisionTaskBuilder<TWorkflow>> DefaultCase { get; set; }
+
+        public Action<DecisionTaskBuilder<TWorkflow>> this[string @case]
+        {
+            set => _cases[@case] = value;
+        }
+
+        internal IReadOnlyDictionary<string, Action<DecisionTaskBuilder<TWorkflow>>> Cases => _cases;
+    }
+}

--- a/src/ConductorSharp.Engine/Builders/WorkflowDefinitionBuilder.cs
+++ b/src/ConductorSharp.Engine/Builders/WorkflowDefinitionBuilder.cs
@@ -115,6 +115,7 @@ namespace ConductorSharp.Engine.Builders
             AdditionalTaskParameters additionalParameters = null
         ) where F : IRequest<G> => AddAndReturnBuilder(new SimpleTaskBuilder<F, G>(refference.Body, input.Body, additionalParameters));
 
+        [Obsolete("Use DecisionCases<TWorkflow> overload")]
         public ITaskOptionsBuilder AddTask(
             Expression<Func<TWorkflow, DecisionTaskModel>> taskSelector,
             Expression<Func<TWorkflow, DecisionTaskInput>> expression,
@@ -127,6 +128,30 @@ namespace ConductorSharp.Engine.Builders
             {
                 builder.AddCase(funcase.Item1);
                 funcase.Item2.Invoke(builder);
+            }
+
+            _taskBuilders.Add(builder);
+            return builder;
+        }
+
+        public ITaskOptionsBuilder AddTask(
+            Expression<Func<TWorkflow, DecisionTaskModel>> taskSelector,
+            Expression<Func<TWorkflow, DecisionTaskInput>> expression,
+            DecisionCases<TWorkflow> decisionCases
+        )
+        {
+            var builder = new DecisionTaskBuilder<TWorkflow>(taskSelector.Body, expression.Body);
+
+            foreach (var @case in decisionCases.Cases)
+            {
+                builder.AddCase(@case.Key);
+                @case.Value(builder);
+            }
+
+            if (decisionCases.DefaultCase != null)
+            {
+                builder.AddDefaultCase();
+                decisionCases.DefaultCase(builder);
             }
 
             _taskBuilders.Add(builder);

--- a/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
+++ b/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
@@ -13,6 +13,7 @@
     <None Remove="Samples\Workflows\ConditionallySendCustomerNotificationOutput.json" />
     <None Remove="Samples\Workflows\DecisionInDecision.json" />
     <None Remove="Samples\Workflows\NestedObjects.json" />
+    <None Remove="Samples\Workflows\NewDecisionMethod.json" />
     <None Remove="Samples\Workflows\OptionalTaskWorkflow.json" />
     <None Remove="Samples\Workflows\ScaffoldedWorkflows.json" />
     <None Remove="Samples\Workflows\SendCustomerNotification.json" />
@@ -29,6 +30,7 @@
     <EmbeddedResource Include="Samples\Tasks\CustomerGet.json" />
     <EmbeddedResource Include="Samples\Tasks\EmailPrepare.json" />
     <EmbeddedResource Include="Samples\Workflows\Arrays.json" />
+    <EmbeddedResource Include="Samples\Workflows\NewDecisionMethod.json" />
     <EmbeddedResource Include="Samples\Workflows\ScaffoldedWorkflows.json" />
     <EmbeddedResource Include="Samples\Workflows\OptionalTaskWorkflow.json" />
     <EmbeddedResource Include="Samples\Workflows\NestedObjects.json" />

--- a/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
@@ -105,5 +105,14 @@ namespace ConductorSharp.Engine.Tests.Integration
 
             Assert.Equal(expectedDefinition, definition);
         }
+
+        [Fact]
+        public void BuilderReturnsCorrectDefinitionNewDecision()
+        {
+            var definition = SerializationUtil.SerializeObject(new NewDecisionMethod().GetDefinition());
+            var expectedDefinition = EmbeddedFileHelper.GetLinesFromEmbeddedFile("~/Samples/Workflows/NewDecisionMethod.json");
+
+            Assert.Equal(expectedDefinition, definition);
+        }
     }
 }

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/DecisionInDecision.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/DecisionInDecision.json
@@ -117,6 +117,116 @@
       "asyncComplete": false,
       "loopCondition": null,
       "loopOver": null
+    },
+    {
+      "queryExpression": null,
+      "name": "DECISION_send_notification_decision_new_method",
+      "taskReferenceName": "send_notification_decision_new_method",
+      "description": null,
+      "inputParameters": {
+        "case_value_param": "${workflow.input.should_send_notification}"
+      },
+      "type": "DECISION",
+      "dynamicTaskNameParam": null,
+      "caseValueParam": "case_value_param",
+      "caseExpression": null,
+      "expression": null,
+      "evaluatorType": null,
+      "scriptExpression": null,
+      "decisionCases": {
+        "YES": [
+          {
+            "queryExpression": null,
+            "name": "DECISION_second_send_notification_decision_new_method",
+            "taskReferenceName": "second_send_notification_decision_new_method",
+            "description": null,
+            "inputParameters": {
+              "case_value_param": "${workflow.input.should_send_notification}"
+            },
+            "type": "DECISION",
+            "dynamicTaskNameParam": null,
+            "caseValueParam": "case_value_param",
+            "caseExpression": null,
+            "expression": null,
+            "evaluatorType": null,
+            "scriptExpression": null,
+            "decisionCases": {
+              "YES": [
+                {
+                  "queryExpression": null,
+                  "name": "NOTIFICATION_send_to_customer",
+                  "taskReferenceName": "send_notification_subworkflow_new_method",
+                  "description": "{\"description\":null}",
+                  "inputParameters": {
+                    "customer_id": "${workflow.input.customer_id}"
+                  },
+                  "type": "SUB_WORKFLOW",
+                  "dynamicTaskNameParam": null,
+                  "caseValueParam": null,
+                  "caseExpression": null,
+                  "expression": null,
+                  "evaluatorType": null,
+                  "scriptExpression": null,
+                  "decisionCases": null,
+                  "dynamicForkJoinTasksParam": null,
+                  "dynamicForkTasksParam": null,
+                  "dynamicForkTasksInputParamName": null,
+                  "defaultCase": null,
+                  "forkTasks": null,
+                  "startDelay": 0,
+                  "subWorkflowParam": {
+                    "name": "NOTIFICATION_send_to_customer",
+                    "version": 1,
+                    "taskToDomain": null,
+                    "workflowDefinition": null
+                  },
+                  "joinOn": null,
+                  "sink": null,
+                  "optional": false,
+                  "taskDefinition": null,
+                  "rateLimited": false,
+                  "defaultExclusiveJoinTask": null,
+                  "asyncComplete": false,
+                  "loopCondition": null,
+                  "loopOver": null
+                }
+              ]
+            },
+            "dynamicForkJoinTasksParam": null,
+            "dynamicForkTasksParam": null,
+            "dynamicForkTasksInputParamName": null,
+            "defaultCase": null,
+            "forkTasks": null,
+            "startDelay": 0,
+            "subWorkflowParam": null,
+            "joinOn": null,
+            "sink": null,
+            "optional": false,
+            "taskDefinition": null,
+            "rateLimited": false,
+            "defaultExclusiveJoinTask": null,
+            "asyncComplete": false,
+            "loopCondition": null,
+            "loopOver": null
+          }
+        ]
+      },
+      "dynamicForkJoinTasksParam": null,
+      "dynamicForkTasksParam": null,
+      "dynamicForkTasksInputParamName": null,
+      "defaultCase": null,
+      "forkTasks": null,
+      "startDelay": 0,
+      "subWorkflowParam": null,
+      "joinOn": null,
+      "sink": null,
+      "optional": false,
+      "taskDefinition": null,
+      "rateLimited": false,
+      "defaultExclusiveJoinTask": null,
+      "asyncComplete": false,
+      "loopCondition": null,
+      "loopOver": null
     }
   ],
   "inputParameters": [

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/NewDecisionMethod.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/NewDecisionMethod.cs
@@ -1,0 +1,46 @@
+﻿using ConductorSharp.Engine.Builders;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConductorSharp.Engine.Tests.Samples.Workflows
+{
+    public class NewDecisionMethodInput : WorkflowInput<NewDecisionMethodOutput>
+    {
+        public string DecisionValue { get; set; }
+    }
+
+    public class NewDecisionMethodOutput : WorkflowOutput { }
+
+    public class NewDecisionMethod : Workflow<NewDecisionMethodInput, NewDecisionMethodOutput>
+    {
+        public DecisionTaskModel Decision { get; set; }
+        public CustomerGetV1 GetCustomer { get; set; }
+        public CustomerGetV1 GetCustomerDefault { get; set; }
+
+        public override WorkflowDefinition GetDefinition()
+        {
+            var builder = new WorkflowDefinitionBuilder<NewDecisionMethod>();
+
+            builder.AddTask(
+                wf => wf.Decision,
+                wf => new() { CaseValueParam = wf.WorkflowInput.DecisionValue },
+                new DecisionCases<NewDecisionMethod>
+                {
+                    ["NonDefaultCase"] = builder =>
+                    {
+                        builder.WithTask(wf => wf.GetCustomer, wf => new() { CustomerId = 1 });
+                    },
+                    DefaultCase = builder =>
+                    {
+                        builder.WithTask(wf => wf.GetCustomerDefault, wf => new() { CustomerId = 2 });
+                    }
+                }
+            );
+
+            return builder.Build(opts => opts.Version = 1);
+        }
+    }
+}

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/NewDecisionMethod.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/NewDecisionMethod.json
@@ -1,0 +1,127 @@
+{
+  "ownerApp": null,
+  "createTime": 0,
+  "updateTime": 0,
+  "createdBy": null,
+  "updatedBy": null,
+  "name": "new_decision_method",
+  "description": "{\"description\":null,\"labels\":null}",
+  "version": 1,
+  "tasks": [
+    {
+      "queryExpression": null,
+      "name": "DECISION_decision",
+      "taskReferenceName": "decision",
+      "description": null,
+      "inputParameters": {
+        "case_value_param": "${workflow.input.decision_value}"
+      },
+      "type": "DECISION",
+      "dynamicTaskNameParam": null,
+      "caseValueParam": "case_value_param",
+      "caseExpression": null,
+      "expression": null,
+      "evaluatorType": null,
+      "scriptExpression": null,
+      "decisionCases": {
+        "NonDefaultCase": [
+          {
+            "queryExpression": null,
+            "name": "CUSTOMER_get",
+            "taskReferenceName": "get_customer",
+            "description": "{\"description\":null}",
+            "inputParameters": {
+              "customer_id": 1
+            },
+            "type": "SIMPLE",
+            "dynamicTaskNameParam": null,
+            "caseValueParam": null,
+            "caseExpression": null,
+            "expression": null,
+            "evaluatorType": null,
+            "scriptExpression": null,
+            "decisionCases": null,
+            "dynamicForkJoinTasksParam": null,
+            "dynamicForkTasksParam": null,
+            "dynamicForkTasksInputParamName": null,
+            "defaultCase": null,
+            "forkTasks": null,
+            "startDelay": 0,
+            "subWorkflowParam": null,
+            "joinOn": null,
+            "sink": null,
+            "optional": false,
+            "taskDefinition": null,
+            "rateLimited": false,
+            "defaultExclusiveJoinTask": null,
+            "asyncComplete": false,
+            "loopCondition": null,
+            "loopOver": null
+          }
+        ]
+      },
+      "dynamicForkJoinTasksParam": null,
+      "dynamicForkTasksParam": null,
+      "dynamicForkTasksInputParamName": null,
+      "defaultCase": [
+        {
+          "queryExpression": null,
+          "name": "CUSTOMER_get",
+          "taskReferenceName": "get_customer_default",
+          "description": "{\"description\":null}",
+          "inputParameters": {
+            "customer_id": 2
+          },
+          "type": "SIMPLE",
+          "dynamicTaskNameParam": null,
+          "caseValueParam": null,
+          "caseExpression": null,
+          "expression": null,
+          "evaluatorType": null,
+          "scriptExpression": null,
+          "decisionCases": null,
+          "dynamicForkJoinTasksParam": null,
+          "dynamicForkTasksParam": null,
+          "dynamicForkTasksInputParamName": null,
+          "defaultCase": null,
+          "forkTasks": null,
+          "startDelay": 0,
+          "subWorkflowParam": null,
+          "joinOn": null,
+          "sink": null,
+          "optional": false,
+          "taskDefinition": null,
+          "rateLimited": false,
+          "defaultExclusiveJoinTask": null,
+          "asyncComplete": false,
+          "loopCondition": null,
+          "loopOver": null
+        }
+      ],
+      "forkTasks": null,
+      "startDelay": 0,
+      "subWorkflowParam": null,
+      "joinOn": null,
+      "sink": null,
+      "optional": false,
+      "taskDefinition": null,
+      "rateLimited": false,
+      "defaultExclusiveJoinTask": null,
+      "asyncComplete": false,
+      "loopCondition": null,
+      "loopOver": null
+    }
+  ],
+  "inputParameters": [
+    "{\"decision_value\":{\"value\":\"\",\"description\":\" (optional)\"}}"
+  ],
+  "outputParameters": null,
+  "failureWorkflow": null,
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": true,
+  "ownerEmail": null,
+  "timeoutPolicy": null,
+  "timeoutSeconds": 0,
+  "variables": null
+}


### PR DESCRIPTION
Added a new way of specifying decision tasks.
Now we have the ability to specify the default case


Usage:

```
builder.AddTask(
                wf => wf.Decision,
                wf => new() { CaseValueParam = wf.WorkflowInput.DecisionValue },
                new DecisionCases<NewDecisionMethod> // This will be simplifed to new() once we remove old way of creating decision tasks.
                {
                    ["NonDefaultCase"] = builder =>
                    {
                        builder.WithTask(wf => wf.GetCustomer, wf => new() { CustomerId = 1 });
                    },
                    DefaultCase = builder =>
                    {
                        builder.WithTask(wf => wf.GetCustomerDefault, wf => new() { CustomerId = 2 });
                    }
                }
            );
```
This PR will also deprecate old way of creating decision tasks.
