### PR TITLE
Add support for c# inline lambda tasks

### DIFF
--- a/src/ConductorSharp.Engine/Builders/CSharpLambdaTaskBuilder.cs
+++ b/src/ConductorSharp.Engine/Builders/CSharpLambdaTaskBuilder.cs
@@ -1,0 +1,43 @@
+﻿using ConductorSharp.Client.Model.Common;
+using ConductorSharp.Engine.Handlers;
+using ConductorSharp.Engine.Interface;
+using MediatR;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace ConductorSharp.Engine.Builders
+{
+    internal class CSharpLambdaTaskBuilder<TInput, TOutput> : BaseTaskBuilder<TInput, TOutput> where TInput : IRequest<TOutput>
+    {
+        public CSharpLambdaTaskBuilder(Expression taskExpression, Expression memberExpression, string workflowName)
+            : base(taskExpression, memberExpression)
+        {
+            LambdaIdentifier = $"{workflowName}.{_taskRefferenceName}";
+        }
+
+        public string LambdaIdentifier { get; }
+
+        public override WorkflowDefinition.Task[] Build()
+        {
+            return new WorkflowDefinition.Task[]
+            {
+                new WorkflowDefinition.Task
+                {
+                    Name = _taskName,
+                    TaskReferenceName = LambdaIdentifier,
+                    Type = "SIMPLE",
+                    InputParameters = new JObject
+                    {
+                        new JProperty(CSharpLambdaTaskInput.LambdaIdenfitierPropName, LambdaIdentifier),
+                        new JProperty(CSharpLambdaTaskInput.TaskInputPropName, _inputParameters)
+                    },
+                    Description = new JObject { new JProperty("description", _description) }.ToString(Newtonsoft.Json.Formatting.None),
+                    Optional = _additionalParameters?.Optional == true,
+                }
+            };
+        }
+    }
+}

--- a/src/ConductorSharp.Engine/Builders/CSharpLambdaTaskBuilder.cs
+++ b/src/ConductorSharp.Engine/Builders/CSharpLambdaTaskBuilder.cs
@@ -27,7 +27,7 @@ namespace ConductorSharp.Engine.Builders
                 new WorkflowDefinition.Task
                 {
                     Name = _taskName,
-                    TaskReferenceName = LambdaIdentifier,
+                    TaskReferenceName = _taskRefferenceName,
                     Type = "SIMPLE",
                     InputParameters = new JObject
                     {

--- a/src/ConductorSharp.Engine/Builders/Workflow.cs
+++ b/src/ConductorSharp.Engine/Builders/Workflow.cs
@@ -21,7 +21,7 @@ namespace ConductorSharp.Engine.Builders
         public TInput WorkflowInput { get; set; }
         public TOutput WorkflowOutput { get; set; }
         public WorkflowId Id { get; set; }
-        public CSharpLambda[] Lambdas { get; private set; }
+        public CSharpLambda[] Lambdas { get; protected set; }
 
         public abstract WorkflowDefinition GetDefinition();
     }

--- a/src/ConductorSharp.Engine/Builders/Workflow.cs
+++ b/src/ConductorSharp.Engine/Builders/Workflow.cs
@@ -1,6 +1,7 @@
 ﻿using ConductorSharp.Client.Model.Common;
 using ConductorSharp.Engine.Interface;
 using ConductorSharp.Engine.Model;
+using ConductorSharp.Engine.Util;
 using MediatR;
 
 namespace ConductorSharp.Engine.Builders
@@ -20,6 +21,7 @@ namespace ConductorSharp.Engine.Builders
         public TInput WorkflowInput { get; set; }
         public TOutput WorkflowOutput { get; set; }
         public WorkflowId Id { get; set; }
+        public CSharpLambda[] Lambdas { get; private set; }
 
         public abstract WorkflowDefinition GetDefinition();
     }

--- a/src/ConductorSharp.Engine/Builders/WorkflowDefinitionBuilder.cs
+++ b/src/ConductorSharp.Engine/Builders/WorkflowDefinitionBuilder.cs
@@ -175,7 +175,7 @@ namespace ConductorSharp.Engine.Builders
             Func<TInput, TOutput> handler
         ) where TInput : IRequest<TOutput>
         {
-            var builder = new CSharpLambdaTaskBuilder<TInput, TOutput>(reference, input, _name);
+            var builder = new CSharpLambdaTaskBuilder<TInput, TOutput>(reference.Body, input.Body, _name);
             _lambdas.Add(new CSharpLambda(builder.LambdaIdentifier, handler, typeof(TInput)));
             return AddAndReturnBuilder(builder);
         }

--- a/src/ConductorSharp.Engine/Builders/WorkflowDefinitionBuilder.cs
+++ b/src/ConductorSharp.Engine/Builders/WorkflowDefinitionBuilder.cs
@@ -24,7 +24,7 @@ namespace ConductorSharp.Engine.Builders
         private List<ITaskBuilder> _taskBuilders = new();
         private readonly List<CSharpLambda> _lambdas = new();
 
-        internal CSharpLambda[] Lambdas => _lambdas.ToArray();
+        public CSharpLambda[] Lambdas => _lambdas.ToArray();
 
         public WorkflowDefinitionBuilder()
         {

--- a/src/ConductorSharp.Engine/Extensions/ConductorSharpBuilder.cs
+++ b/src/ConductorSharp.Engine/Extensions/ConductorSharpBuilder.cs
@@ -72,7 +72,7 @@ namespace ConductorSharp.Engine.Extensions
 
         public IExecutionManagerBuilder AddCSharpLambdaTasks()
         {
-            _builder.RegisterWorkerTask<CSharpLambdaTaskHandler>();
+            Builder.RegisterWorkerTask<CSharpLambdaTaskHandler>();
             return this;
         }
     }

--- a/src/ConductorSharp.Engine/Extensions/ConductorSharpBuilder.cs
+++ b/src/ConductorSharp.Engine/Extensions/ConductorSharpBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using ConductorSharp.Engine.Behaviors;
+using ConductorSharp.Engine.Handlers;
 using ConductorSharp.Engine.Health;
 using ConductorSharp.Engine.Interface;
 using ConductorSharp.Engine.Polling;
@@ -66,6 +67,12 @@ namespace ConductorSharp.Engine.Extensions
         public IExecutionManagerBuilder SetHealthCheckService<T>() where T : IConductorSharpHealthService
         {
             _builder.RegisterType<T>().As<IConductorSharpHealthService>().SingleInstance();
+            return this;
+        }
+
+        public IExecutionManagerBuilder AddCSharpLambdaTasks()
+        {
+            _builder.RegisterWorkerTask<CSharpLambdaTaskHandler>();
             return this;
         }
     }

--- a/src/ConductorSharp.Engine/Extensions/ContainerBuilderExtensions.cs
+++ b/src/ConductorSharp.Engine/Extensions/ContainerBuilderExtensions.cs
@@ -115,12 +115,12 @@ namespace ConductorSharp.Engine.Extensions
         public static void RegisterWorkflow<TWorkflow>(this ContainerBuilder builder) where TWorkflow : ITypedWorkflow, new()
         {
             var workflow = new TWorkflow();
+            builder.RegisterInstance(workflow.GetDefinition());
             if (workflow.Lambdas != null)
             {
                 foreach (var lambda in workflow.Lambdas)
                     builder.RegisterInstance(lambda);
             }
-            builder.RegisterInstance(workflow.GetDefinition());
         }
 
         public static void RegisterTaskDefinition(this ContainerBuilder builder, TaskDefinition definition) => builder.RegisterInstance(definition);

--- a/src/ConductorSharp.Engine/Extensions/ContainerBuilderExtensions.cs
+++ b/src/ConductorSharp.Engine/Extensions/ContainerBuilderExtensions.cs
@@ -112,8 +112,16 @@ namespace ConductorSharp.Engine.Extensions
             builder.RegisterInstance(definition);
         }
 
-        public static void RegisterWorkflow<TWorkflow>(this ContainerBuilder builder) where TWorkflow : ITypedWorkflow, new() =>
-            builder.RegisterInstance(new TWorkflow().GetDefinition());
+        public static void RegisterWorkflow<TWorkflow>(this ContainerBuilder builder) where TWorkflow : ITypedWorkflow, new()
+        {
+            var workflow = new TWorkflow();
+            if (workflow.Lambdas != null)
+            {
+                foreach (var lambda in workflow.Lambdas)
+                    builder.RegisterInstance(lambda);
+            }
+            builder.RegisterInstance(workflow.GetDefinition());
+        }
 
         public static void RegisterTaskDefinition(this ContainerBuilder builder, TaskDefinition definition) => builder.RegisterInstance(definition);
         // TODO: add RegisterEventHandlerDefinition

--- a/src/ConductorSharp.Engine/Extensions/IExecutionManagerBuilder.cs
+++ b/src/ConductorSharp.Engine/Extensions/IExecutionManagerBuilder.cs
@@ -9,5 +9,6 @@ namespace ConductorSharp.Engine.Extensions
     {
         IExecutionManagerBuilder AddPipelines(Action<IPipelineBuilder> pipelines);
         IExecutionManagerBuilder SetHealthCheckService<T>() where T : IConductorSharpHealthService;
+        IExecutionManagerBuilder AddCSharpLambdaTasks();
     }
 }

--- a/src/ConductorSharp.Engine/Handlers/CSharpLambdaTaskHandler.cs
+++ b/src/ConductorSharp.Engine/Handlers/CSharpLambdaTaskHandler.cs
@@ -1,4 +1,5 @@
-﻿using ConductorSharp.Engine.Interface;
+﻿using ConductorSharp.Client;
+using ConductorSharp.Engine.Interface;
 using ConductorSharp.Engine.Util;
 using MediatR;
 using Newtonsoft.Json;
@@ -40,7 +41,7 @@ namespace ConductorSharp.Engine.Handlers
             if (lambda == null)
                 throw new NotImplementedException($"No corresponding lambda for identifier: {request.LambdaIdentifier}");
 
-            return Task.FromResult(lambda.Handler.DynamicInvoke(request.TaskInput.ToObject(lambda.InputType)));
+            return Task.FromResult(lambda.Handler.DynamicInvoke(request.TaskInput.ToObject(lambda.InputType, ConductorConstants.IoJsonSerializer)));
         }
     }
 }

--- a/src/ConductorSharp.Engine/Handlers/CSharpLambdaTaskHandler.cs
+++ b/src/ConductorSharp.Engine/Handlers/CSharpLambdaTaskHandler.cs
@@ -1,0 +1,43 @@
+﻿using ConductorSharp.Engine.Interface;
+using ConductorSharp.Engine.Util;
+using MediatR;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ConductorSharp.Engine.Handlers
+{
+    internal class CSharpLambdaTaskInput : IRequest<object>
+    {
+        public const string LambdaIdenfitierPropName = "lambda_identifier";
+        public const string TaskInputPropName = "task_input";
+
+        [JsonProperty(LambdaIdenfitierPropName)]
+        public string LambdaIdentifier { get; set; }
+
+        [JsonProperty(TaskInputPropName)]
+        public JObject TaskInput { get; set; }
+    }
+
+    [OriginalName(TaskName)]
+    internal class CSharpLambdaTaskHandler : ITaskRequestHandler<CSharpLambdaTaskInput, object>
+    {
+        public const string TaskName = "___CONDUCTOR_SHARP_INLINE_LAMBDA_TASK";
+        private readonly Dictionary<string, CSharpLambda> _lambdas;
+
+        public CSharpLambdaTaskHandler(IEnumerable<CSharpLambda> lambdas) => _lambdas = lambdas.ToDictionary(lambda => lambda.LambdaIdentifier);
+
+        public Task<object> Handle(CSharpLambdaTaskInput request, CancellationToken cancellationToken)
+        {
+            var lambda = _lambdas.GetValueOrDefault(request.LambdaIdentifier);
+            if (lambda == null)
+                throw new NotImplementedException($"No corresponding lambda for identifier: {request.LambdaIdentifier}");
+
+            return Task.FromResult(lambda.Handler.DynamicInvoke(request.TaskInput.ToObject(lambda.InputType)));
+        }
+    }
+}

--- a/src/ConductorSharp.Engine/Handlers/CSharpLambdaTaskHandler.cs
+++ b/src/ConductorSharp.Engine/Handlers/CSharpLambdaTaskHandler.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,16 +18,18 @@ namespace ConductorSharp.Engine.Handlers
         public const string TaskInputPropName = "task_input";
 
         [JsonProperty(LambdaIdenfitierPropName)]
+        [Required]
         public string LambdaIdentifier { get; set; }
 
         [JsonProperty(TaskInputPropName)]
+        [Required]
         public JObject TaskInput { get; set; }
     }
 
     [OriginalName(TaskName)]
     internal class CSharpLambdaTaskHandler : ITaskRequestHandler<CSharpLambdaTaskInput, object>
     {
-        public const string TaskName = "___CONDUCTOR_SHARP_INLINE_LAMBDA_TASK";
+        public const string TaskName = "_CONDUCTOR_SHARP_inline_lambda_task";
         private readonly Dictionary<string, CSharpLambda> _lambdas;
 
         public CSharpLambdaTaskHandler(IEnumerable<CSharpLambda> lambdas) => _lambdas = lambdas.ToDictionary(lambda => lambda.LambdaIdentifier);

--- a/src/ConductorSharp.Engine/Interface/ITypedWorkflow.cs
+++ b/src/ConductorSharp.Engine/Interface/ITypedWorkflow.cs
@@ -1,9 +1,11 @@
 ﻿using ConductorSharp.Client.Model.Common;
+using ConductorSharp.Engine.Util;
 
 namespace ConductorSharp.Engine.Interface
 {
     public interface ITypedWorkflow : INameable
     {
         WorkflowDefinition GetDefinition();
+        CSharpLambda[] Lambdas { get; }
     }
 }

--- a/src/ConductorSharp.Engine/Model/CSharpLambdaTaskModel.cs
+++ b/src/ConductorSharp.Engine/Model/CSharpLambdaTaskModel.cs
@@ -1,0 +1,12 @@
+﻿using ConductorSharp.Engine.Handlers;
+using ConductorSharp.Engine.Util;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ConductorSharp.Engine.Model
+{
+    [OriginalName(CSharpLambdaTaskHandler.TaskName)]
+    public sealed class CSharpLambdaTaskModel<TInput, TOutput> : SimpleTaskModel<TInput, TOutput> where TInput : IRequest<TOutput> { }
+}

--- a/src/ConductorSharp.Engine/Model/CSharpLambdaTaskModel.cs
+++ b/src/ConductorSharp.Engine/Model/CSharpLambdaTaskModel.cs
@@ -8,5 +8,5 @@ using System.Text;
 namespace ConductorSharp.Engine.Model
 {
     [OriginalName(CSharpLambdaTaskHandler.TaskName)]
-    public sealed class CSharpLambdaTaskModel<TInput, TOutput> : SimpleTaskModel<TInput, TOutput> where TInput : IRequest<TOutput> { }
+    public sealed class CSharpLambdaTaskModel<TInput, TOutput> : TaskModel<TInput, TOutput> where TInput : IRequest<TOutput> { }
 }

--- a/src/ConductorSharp.Engine/Util/CSharpLambda.cs
+++ b/src/ConductorSharp.Engine/Util/CSharpLambda.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace ConductorSharp.Engine.Util
+{
+    public class CSharpLambda
+    {
+        public CSharpLambda(string lambdaIdentifier, Delegate handler, Type inputType)
+        {
+            LambdaIdentifier = lambdaIdentifier;
+            Handler = handler;
+            InputType = inputType;
+        }
+
+        public string LambdaIdentifier { get; }
+        public Delegate Handler { get; }
+        public Type InputType { get; }
+    }
+}

--- a/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
+++ b/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
@@ -11,6 +11,7 @@
     <None Remove="Samples\Tasks\EmailPrepare.json" />
     <None Remove="Samples\Workflows\Arrays.json" />
     <None Remove="Samples\Workflows\ConditionallySendCustomerNotificationOutput.json" />
+    <None Remove="Samples\Workflows\CSharpLambdaWorkflow.json" />
     <None Remove="Samples\Workflows\DecisionInDecision.json" />
     <None Remove="Samples\Workflows\DynamicTask.json" />
     <None Remove="Samples\Workflows\NestedObjects.json" />
@@ -23,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Samples\Workflows\CSharpLambdaWorkflow.json" />
     <EmbeddedResource Include="Samples\Workflows\DecisionInDecision.json" />
   </ItemGroup>
 

--- a/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
@@ -114,5 +114,28 @@ namespace ConductorSharp.Engine.Tests.Integration
 
             Assert.Equal(expectedDefinition, definition);
         }
+
+        [Fact]
+        public void BuilderReturnsCorrectDefinitionCSharpLambdaWorkflow()
+        {
+            var workflow = new CSharpLambdaWorkflow();
+            var definition = SerializationUtil.SerializeObject(workflow.GetDefinition());
+            var expectedDefinition = EmbeddedFileHelper.GetLinesFromEmbeddedFile("~/Samples/Workflows/CSharpLambdaWorkflow.json");
+
+            Assert.Equal(expectedDefinition, definition);
+            Assert.Collection(
+                workflow.Lambdas,
+                lambda =>
+                {
+                    Assert.Equal("c_sharp_lambda_workflow.first_task", lambda.LambdaIdentifier);
+                    Assert.Equal(typeof(CSharpLambdaWorkflow.TaskInput), lambda.InputType);
+                },
+                lambda =>
+                {
+                    Assert.Equal("c_sharp_lambda_workflow.second_task", lambda.LambdaIdentifier);
+                    Assert.Equal(typeof(CSharpLambdaWorkflow.TaskInput), lambda.InputType);
+                }
+            );
+        }
     }
 }

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/CSharpLambdaWorkflow.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/CSharpLambdaWorkflow.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConductorSharp.Engine.Tests.Samples.Workflows
+{
+    public class CSharpLambdaWorkflowInput : WorkflowInput<CSharpLambdaWorkflowOutput>
+    {
+        public string InputProp { get; set; }
+    }
+
+    public class CSharpLambdaWorkflowOutput : WorkflowOutput { }
+
+    public class CSharpLambdaWorkflow : Workflow<CSharpLambdaWorkflowInput, CSharpLambdaWorkflowOutput>
+    {
+        public class TaskInput : IRequest<TaskOutput>
+        {
+            public string InputProp { get; set; }
+        }
+
+        public class TaskOutput
+        {
+            public string OutputProp { get; set; }
+        }
+
+        public CSharpLambdaTaskModel<TaskInput, TaskOutput> FirstTask { get; set; }
+        public CSharpLambdaTaskModel<TaskInput, TaskOutput> SecondTask { get; set; }
+
+        public override WorkflowDefinition GetDefinition()
+        {
+            var builder = new WorkflowDefinitionBuilder<CSharpLambdaWorkflow>();
+
+            builder.AddTask(
+                wf => wf.FirstTask,
+                wf => new() { InputProp = wf.WorkflowInput.InputProp },
+                input => new TaskOutput { OutputProp = input.InputProp }
+            );
+
+            builder.AddTask(
+                wf => wf.SecondTask,
+                wf => new() { InputProp = wf.FirstTask.Output.OutputProp },
+                input => new TaskOutput { OutputProp = input.InputProp }
+            );
+
+            Lambdas = builder.Lambdas;
+
+            return builder.Build(opts => opts.Version = 1);
+        }
+    }
+}

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/CSharpLambdaWorkflow.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/CSharpLambdaWorkflow.json
@@ -1,0 +1,96 @@
+{
+  "ownerApp": null,
+  "createTime": 0,
+  "updateTime": 0,
+  "createdBy": null,
+  "updatedBy": null,
+  "name": "c_sharp_lambda_workflow",
+  "description": "{\"description\":null,\"labels\":null}",
+  "version": 1,
+  "tasks": [
+    {
+      "queryExpression": null,
+      "name": "_CONDUCTOR_SHARP_inline_lambda_task",
+      "taskReferenceName": "first_task",
+      "description": "{\"description\":null}",
+      "inputParameters": {
+        "lambda_identifier": "c_sharp_lambda_workflow.first_task",
+        "task_input": {
+          "input_prop": "${workflow.input.input_prop}"
+        }
+      },
+      "type": "SIMPLE",
+      "dynamicTaskNameParam": null,
+      "caseValueParam": null,
+      "caseExpression": null,
+      "expression": null,
+      "evaluatorType": null,
+      "scriptExpression": null,
+      "decisionCases": null,
+      "dynamicForkJoinTasksParam": null,
+      "dynamicForkTasksParam": null,
+      "dynamicForkTasksInputParamName": null,
+      "defaultCase": null,
+      "forkTasks": null,
+      "startDelay": 0,
+      "subWorkflowParam": null,
+      "joinOn": null,
+      "sink": null,
+      "optional": false,
+      "taskDefinition": null,
+      "rateLimited": false,
+      "defaultExclusiveJoinTask": null,
+      "asyncComplete": false,
+      "loopCondition": null,
+      "loopOver": null
+    },
+    {
+      "queryExpression": null,
+      "name": "_CONDUCTOR_SHARP_inline_lambda_task",
+      "taskReferenceName": "second_task",
+      "description": "{\"description\":null}",
+      "inputParameters": {
+        "lambda_identifier": "c_sharp_lambda_workflow.second_task",
+        "task_input": {
+          "input_prop": "${first_task.output.output_prop}"
+        }
+      },
+      "type": "SIMPLE",
+      "dynamicTaskNameParam": null,
+      "caseValueParam": null,
+      "caseExpression": null,
+      "expression": null,
+      "evaluatorType": null,
+      "scriptExpression": null,
+      "decisionCases": null,
+      "dynamicForkJoinTasksParam": null,
+      "dynamicForkTasksParam": null,
+      "dynamicForkTasksInputParamName": null,
+      "defaultCase": null,
+      "forkTasks": null,
+      "startDelay": 0,
+      "subWorkflowParam": null,
+      "joinOn": null,
+      "sink": null,
+      "optional": false,
+      "taskDefinition": null,
+      "rateLimited": false,
+      "defaultExclusiveJoinTask": null,
+      "asyncComplete": false,
+      "loopCondition": null,
+      "loopOver": null
+    }
+  ],
+  "inputParameters": [
+    "{\"input_prop\":{\"value\":\"\",\"description\":\" (optional)\"}}"
+  ],
+  "outputParameters": null,
+  "failureWorkflow": null,
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": true,
+  "ownerEmail": null,
+  "timeoutPolicy": null,
+  "timeoutSeconds": 0,
+  "variables": null
+}


### PR DESCRIPTION
```

  var builder = new WorkflowDefinitionBuilder<CSharpLambdaWorkflow>();

  builder.AddTask(wf => wf.FirstTask, wf => new()
  {
      InputProp = wf.WorkflowInput.InputProp
  }, input =>
  {
      string modify = input.InputProp + "a";
      return new TaskOutput { OutputProp = modify };
  });

  builder.AddTask(wf => wf.SecondTask, wf => new()
  {
      InputProp = wf.FirstTask.Output.OutputProp
  }, input =>
  {
      string modify = input.InputProp + "b";
      return new TaskOutput { OutputProp = modify };
  });

  Lambdas = builder.Lambdas;

  return builder.Build(opts =>
  {
      opts.Version = 1;
      opts.OwnerEmail = "test@test.com";
  });


```