### PR TITLE
Use consistent snake case method when adding a task and accessing task output properties

### DIFF
--- a/src/ConductorSharp.Engine/Util/ExpressionUtil.cs
+++ b/src/ConductorSharp.Engine/Util/ExpressionUtil.cs
@@ -210,7 +210,7 @@ namespace ConductorSharp.Engine.Util
                 memberName = propertyInfo.GetCustomAttribute<JsonPropertyAttribute>(true)?.PropertyName;
 
             if (memberName == null)
-                memberName = SnakeCaseUtil.ToLowercasedPrefixSnakeCase(propertyInfo.Name);
+                memberName = SnakeCaseUtil.ToSnakeCase(propertyInfo.Name);
 
             return memberName;
         }

--- a/src/ConductorSharp.Engine/Util/SnakeCaseUtil.cs
+++ b/src/ConductorSharp.Engine/Util/SnakeCaseUtil.cs
@@ -31,30 +31,6 @@ namespace ConductorSharp.Engine.Util
             return string.Join("_", chunks);
         }
 
-        public static string ToLowercasedPrefixSnakeCase(string str)
-        {
-            str = str.Replace("-", "");
-            var pattern = new Regex(@"[A-Z0-9_]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z][0-9]+|[A-Z]");
-            var prefixPattern = new Regex(@"[A-Z0-9]{2,}");
-
-            var matches = pattern.Matches(str);
-
-            var chunks = new List<string>();
-
-            for (var i = 0; i < matches.Count; i++)
-            {
-                if (i == 0 && prefixPattern.Match(matches[i].Value).Success)
-                {
-                    chunks.Add(matches[i].Value.Replace("_", "").ToLower());
-                    continue;
-                }
-                else
-                    chunks.Add(matches[i].Value.ToLower());
-            }
-
-            return string.Join("_", chunks);
-        }
-
         public static string ToSnakeCase(string str) =>
             string.Concat(str.Select((x, i) => i > 0 && char.IsUpper(x) ? "_" + x.ToString() : x.ToString())).ToLower();
 


### PR DESCRIPTION
This PR fixes bug when certain strings are used as task property names. It results in the inconsistent generation of task reference name in different contexts hence workflow deployment errors are possible.

Example: 
`AddTask(wf => Test1cWorkflow,... `   => `taskReferenceName: "test1c_workflow"`
`wf.Test1cWorkflow.Output.Property` => `test1_c_workflow.output.property`

@ognjenkatic This shouldn't break any existing code.