### PR TITLE
Add support for string addition

### DIFF
--- a/src/ConductorSharp.Engine/Util/ExpressionUtil.cs
+++ b/src/ConductorSharp.Engine/Util/ExpressionUtil.cs
@@ -41,6 +41,9 @@ namespace ConductorSharp.Engine.Util
             if (expression is UnaryExpression unaryEx && unaryEx.NodeType == ExpressionType.Convert)
                 return ParseExpression(unaryEx.Operand);
 
+            if (expression is BinaryExpression binaryEx)
+                return ParseBinaryExpression(binaryEx);
+
             if (
                 expression is MethodCallExpression methodExpression
                 && methodExpression.Method.Name == nameof(string.Format)
@@ -62,6 +65,26 @@ namespace ConductorSharp.Engine.Util
                 return ParseArrayInitalization(newArrayExpression);
 
             return CompileMemberOrNameExpressions(expression);
+        }
+
+        private static object ParseBinaryExpression(BinaryExpression binaryEx)
+        {
+            var left = ParseExpression(binaryEx.Left);
+            var right = ParseExpression(binaryEx.Right);
+
+            switch (binaryEx.NodeType)
+            {
+                case ExpressionType.Add:
+
+                    if (left is string leftStr)
+                        return leftStr + right;
+                    if (right is string rightStr)
+                        return left + rightStr;
+
+                    throw new NotSupportedException($"Expression {left} + {right} not supported");
+                default:
+                    throw new NotSupportedException($"Binary expression with node type {binaryEx.NodeType} not supported");
+            }
         }
 
         private static object ParseConstantExpression(ConstantExpression cex)

--- a/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
+++ b/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
@@ -18,6 +18,7 @@
     <None Remove="Samples\Workflows\PatternTasks.json" />
     <None Remove="Samples\Workflows\ScaffoldedWorkflows.json" />
     <None Remove="Samples\Workflows\SendCustomerNotification.json" />
+    <None Remove="Samples\Workflows\StringAddition.json" />
     <None Remove="Samples\Workflows\StringInterpolation.json" />
     <None Remove="Samples\Workflows\TerminateTaskWorkflow.json" />
     <None Remove="Samples\Workflows\UntypedProperty.json" />
@@ -38,6 +39,7 @@
     <EmbeddedResource Include="Samples\Workflows\OptionalTaskWorkflow.json" />
     <EmbeddedResource Include="Samples\Workflows\NestedObjects.json" />
 	<EmbeddedResource Include="Samples\Workflows\SendCustomerNotification.json" />
+	<EmbeddedResource Include="Samples\Workflows\StringAddition.json" />
 	<EmbeddedResource Include="Samples\Workflows\StringInterpolation.json" />
 	<EmbeddedResource Include="Samples\Workflows\TerminateTaskWorkflow.json" />
 	<EmbeddedResource Include="Samples\Workflows\UntypedProperty.json" />

--- a/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
@@ -132,5 +132,14 @@ namespace ConductorSharp.Engine.Tests.Integration
 
             Assert.Equal(expectedDefinition, definition);
         }
+
+        [Fact]
+        public void BuilderReturnsCorrectDefinitionStringAddition()
+        {
+            var definition = SerializationUtil.SerializeObject(new StringAddition().GetDefinition());
+            var expectedDefinition = EmbeddedFileHelper.GetLinesFromEmbeddedFile("~/Samples/Workflows/StringAddition.json");
+
+            Assert.Equal(expectedDefinition, definition);
+        }
     }
 }

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/StringAddition.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/StringAddition.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConductorSharp.Engine.Tests.Samples.Workflows
+{
+    public class StringAdditionInput : WorkflowInput<StringAdditionOutput>
+    {
+        public string Input { get; set; }
+    }
+
+    public class StringAdditionOutput : WorkflowOutput { }
+
+    [OriginalName("string_addition")]
+    public class StringAddition : Workflow<StringAdditionInput, StringAdditionOutput>
+    {
+        public class StringTaskOutput { }
+
+        public class StringTaskInput : IRequest<StringTaskOutput>
+        {
+            public string Input { get; set; }
+        }
+
+        public LambdaTaskModel<StringTaskInput, StringTaskOutput> StringTask { get; set; }
+
+        public override WorkflowDefinition GetDefinition()
+        {
+            var builder = new WorkflowDefinitionBuilder<StringAddition>();
+
+            builder.AddTask(
+                wf => wf.StringTask,
+                wf =>
+                    new()
+                    {
+                        Input =
+                            1
+                            + "Str_"
+                            + "2Str_"
+                            + wf.WorkflowInput.Input
+                            + $"My input: {wf.WorkflowInput.Input}"
+                            + NamingUtil.NameOf<StringAddition>()
+                            + 1
+                    },
+                ""
+            );
+
+            return builder.Build(opts =>
+            {
+                opts.Version = 1;
+            });
+        }
+    }
+}

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/StringAddition.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/StringAddition.json
@@ -1,0 +1,58 @@
+{
+  "ownerApp": null,
+  "createTime": 0,
+  "updateTime": 0,
+  "createdBy": null,
+  "updatedBy": null,
+  "name": "string_addition",
+  "description": "{\"description\":null,\"labels\":null}",
+  "version": 1,
+  "tasks": [
+    {
+      "queryExpression": null,
+      "name": "LAMBDA_string_task",
+      "taskReferenceName": "string_task",
+      "description": "{\"description\":null}",
+      "inputParameters": {
+        "input": "1Str_2Str_${workflow.input.input}My input: ${workflow.input.input}string_addition1",
+        "scriptExpression": ""
+      },
+      "type": "LAMBDA",
+      "dynamicTaskNameParam": null,
+      "caseValueParam": null,
+      "caseExpression": null,
+      "expression": null,
+      "evaluatorType": null,
+      "scriptExpression": null,
+      "decisionCases": null,
+      "dynamicForkJoinTasksParam": null,
+      "dynamicForkTasksParam": null,
+      "dynamicForkTasksInputParamName": null,
+      "defaultCase": null,
+      "forkTasks": null,
+      "startDelay": 0,
+      "subWorkflowParam": null,
+      "joinOn": null,
+      "sink": null,
+      "optional": false,
+      "taskDefinition": null,
+      "rateLimited": false,
+      "defaultExclusiveJoinTask": null,
+      "asyncComplete": false,
+      "loopCondition": null,
+      "loopOver": null
+    }
+  ],
+  "inputParameters": [
+    "{\"input\":{\"value\":\"\",\"description\":\" (optional)\"}}"
+  ],
+  "outputParameters": null,
+  "failureWorkflow": null,
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": true,
+  "ownerEmail": null,
+  "timeoutPolicy": null,
+  "timeoutSeconds": 0,
+  "variables": null
+}


### PR DESCRIPTION
The following expressions are now supported:


```
builder.AddTask(
                wf => wf.StringTask,
                wf =>
                    new()
                    {
                        Input =
                            1
                            + "Str_"
                            + "2Str_"
                            + wf.WorkflowInput.Input
                            + $"My input: {wf.WorkflowInput.Input}"
                            + NamingUtil.NameOf<StringAddition>()
                            + 1
                    },
                ""
            );
```