### PR TITLE
Use proper function for converting pacscal case to snake case

### DIFF
--- a/src/ConductorSharp.Engine/Builders/TaskDefinitionBuilder.cs
+++ b/src/ConductorSharp.Engine/Builders/TaskDefinitionBuilder.cs
@@ -38,14 +38,8 @@ namespace ConductorSharp.Engine.Builders
                 Description = options.Description ?? DetermineDescription(taskType.GetDocSection("summary")),
                 RetryCount = options.RetryCount,
                 TimeoutSeconds = options.TimeoutSeconds,
-                InputKeys = inputType
-                    .GetProperties()
-                    .Select(a => a.GetDocSection("originalName") ?? SnakeCaseUtil.ToCapitalizedPrefixSnakeCase(a.Name))
-                    .ToList(),
-                OutputKeys = outputType
-                    .GetProperties()
-                    .Select(a => a.GetDocSection("originalName") ?? SnakeCaseUtil.ToCapitalizedPrefixSnakeCase(a.Name))
-                    .ToList(),
+                InputKeys = inputType.GetProperties().Select(a => a.GetDocSection("originalName") ?? SnakeCaseUtil.ToSnakeCase(a.Name)).ToList(),
+                OutputKeys = outputType.GetProperties().Select(a => a.GetDocSection("originalName") ?? SnakeCaseUtil.ToSnakeCase(a.Name)).ToList(),
                 TimeoutPolicy = options.TimeoutPolicy,
                 RetryLogic = options.RetryLogic,
                 RetryDelaySeconds = options.RetryDelaySeconds,


### PR DESCRIPTION
The execution engine outputs properties in snake case but for some properties the task is registered with different output property. This is the problem when task is scaffolded and used in workflows. The problem only occurs if the first part of PascalCase property contains a number.

Example:
Execution manager: Oss10ServiceId(c# Prop) -> oss10_service_id (task property)
Wf registration and scaffolding: Oss10ServiceId(c# Prop) -> Oss10_service_id(registered task property) -> Oss10_service_id(task property used on scaffolded property)
