### PR TITLE
Make builders respect JsonProperty attribute

### DIFF
--- a/src/ConductorSharp.Client/ConductorConstants.cs
+++ b/src/ConductorSharp.Client/ConductorConstants.cs
@@ -5,12 +5,14 @@ namespace ConductorSharp.Client
 {
     public static class ConductorConstants
     {
-        public static string SimpleTask { get; } = "SIMPLE";
-        public static string SubworkflowTask { get; } = "SUB_WORKFLOW";
+        public static string SimpleTask => "SIMPLE";
+
+        public static NamingStrategy IoNamingStrategy { get; } = new SnakeCaseNamingStrategy();
+
         public static JsonSerializer IoJsonSerializer { get; } =
             new()
             {
-                ContractResolver = new DefaultContractResolver { NamingStrategy = new SnakeCaseNamingStrategy() },
+                ContractResolver = new DefaultContractResolver { NamingStrategy = IoNamingStrategy },
                 NullValueHandling = NullValueHandling.Ignore,
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
                 MetadataPropertyHandling = MetadataPropertyHandling.ReadAhead,

--- a/src/ConductorSharp.Engine/Builders/TaskDefinitionBuilder.cs
+++ b/src/ConductorSharp.Engine/Builders/TaskDefinitionBuilder.cs
@@ -7,6 +7,10 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using ConductorSharp.Client;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace ConductorSharp.Engine.Builders
 {
@@ -50,8 +54,8 @@ namespace ConductorSharp.Engine.Builders
                 Description = options.Description ?? DetermineDescription(taskType.GetDocSection("summary")),
                 RetryCount = options.RetryCount,
                 TimeoutSeconds = options.TimeoutSeconds,
-                InputKeys = inputType.GetProperties().Select(a => a.GetDocSection("originalName") ?? SnakeCaseUtil.ToSnakeCase(a.Name)).ToList(),
-                OutputKeys = outputType.GetProperties().Select(a => a.GetDocSection("originalName") ?? SnakeCaseUtil.ToSnakeCase(a.Name)).ToList(),
+                InputKeys = inputType.GetProperties().Select(NamingUtil.GetParameterName).ToList(),
+                OutputKeys = outputType.GetProperties().Select(NamingUtil.GetParameterName).ToList(),
                 TimeoutPolicy = options.TimeoutPolicy,
                 RetryLogic = options.RetryLogic,
                 RetryDelaySeconds = options.RetryDelaySeconds,
@@ -68,9 +72,7 @@ namespace ConductorSharp.Engine.Builders
             };
         }
 
-        private string DetermineRegistrationName(Type taskType) => _taskNameBuilder.Build(taskType);
-
-        private string DetermineDescription(string description, params string[] labels)
+        private static string DetermineDescription(string description)
         {
             var descriptionProperty = string.IsNullOrEmpty(description)
                 ? new JProperty("description", "Missing description")

--- a/src/ConductorSharp.Engine/Builders/WorkflowDefinitionBuilder.cs
+++ b/src/ConductorSharp.Engine/Builders/WorkflowDefinitionBuilder.cs
@@ -109,7 +109,7 @@ namespace ConductorSharp.Engine.Builders
                 var isRequired = prop.GetCustomAttribute<RequiredAttribute>();
                 var description = prop.GetDocSection("summary");
 
-                var propertyName = prop.GetDocSection("originalName") ?? SnakeCaseUtil.ToSnakeCase(prop.Name);
+                var propertyName = NamingUtil.GetParameterName(prop);
 
                 var requiredString = isRequired != null ? "(required)" : "(optional)";
                 BuildContext.Inputs.Add(

--- a/src/ConductorSharp.Engine/Interface/IParameterKeyword.cs
+++ b/src/ConductorSharp.Engine/Interface/IParameterKeyword.cs
@@ -1,7 +1,0 @@
-﻿namespace ConductorSharp.Engine.Interface
-{
-    public interface IParameterKeyword
-    {
-        public string GetValue();
-    }
-}

--- a/src/ConductorSharp.Engine/Util/ExpressionUtil.cs
+++ b/src/ConductorSharp.Engine/Util/ExpressionUtil.cs
@@ -227,22 +227,6 @@ namespace ConductorSharp.Engine.Util
             return false;
         }
 
-        private static string GetMemberName(PropertyInfo propertyInfo)
-        {
-            string memberName = default;
-
-            if (propertyInfo.PropertyType is IParameterKeyword keyword)
-
-                if (memberName == null)
-                    memberName = propertyInfo.GetDocSection("originalName");
-
-            if (memberName == null)
-                memberName = propertyInfo.GetCustomAttribute<JsonPropertyAttribute>(true)?.PropertyName;
-
-            if (memberName == null)
-                memberName = SnakeCaseUtil.ToSnakeCase(propertyInfo.Name);
-
-            return memberName;
-        }
+        private static string GetMemberName(PropertyInfo propertyInfo) => NamingUtil.GetParameterName(propertyInfo);
     }
 }

--- a/src/ConductorSharp.Engine/Util/NamingUtil.cs
+++ b/src/ConductorSharp.Engine/Util/NamingUtil.cs
@@ -1,5 +1,8 @@
 ﻿using ConductorSharp.Engine.Interface;
 using System;
+using System.Reflection;
+using ConductorSharp.Client;
+using Newtonsoft.Json;
 
 namespace ConductorSharp.Engine.Util
 {
@@ -28,6 +31,9 @@ namespace ConductorSharp.Engine.Util
 
         public static string NameOf<TNameable>() where TNameable : INameable => DetermineRegistrationName(typeof(TNameable));
 
-        internal static string DetermineReferenceName(string referenceName) => SnakeCaseUtil.ToCapitalizedPrefixSnakeCase(referenceName);
+        internal static string GetParameterName(PropertyInfo propInfo) =>
+            propInfo.GetDocSection("originalName")
+            ?? propInfo.GetCustomAttribute<JsonPropertyAttribute>(true)?.PropertyName
+            ?? ConductorConstants.IoNamingStrategy.GetPropertyName(propInfo.Name, false);
     }
 }

--- a/test/ConductorSharp.Engine.Tests/Samples/Tasks/CustomerGet.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Tasks/CustomerGet.json
@@ -9,7 +9,7 @@
   "retryCount": 0,
   "timeoutSeconds": 60,
   "inputKeys": [
-    "customer_id"
+    "id"
   ],
   "outputKeys": [
     "name",

--- a/test/ConductorSharp.Engine.Tests/Samples/Workers/GetCustomerHandler.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workers/GetCustomerHandler.cs
@@ -5,6 +5,7 @@ namespace ConductorSharp.Engine.Tests.Samples.Workers;
 public class GetCustomerRequest : IRequest<GetCustomerResponse>
 {
     [Required]
+    [JsonProperty("id")]
     public int CustomerId { get; set; }
 }
 

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/ConditionallySendCustomerNotificationOutput.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/ConditionallySendCustomerNotificationOutput.json
@@ -30,7 +30,7 @@
             "taskReferenceName": "send_notification_subworkflow",
             "description": "{\"description\":null}",
             "inputParameters": {
-              "customer_id": "${workflow.input.customer_id}"
+              "id": "${workflow.input.customer_id}"
             },
             "type": "SUB_WORKFLOW",
             "startDelay": 0,

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/DecisionInDecision.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/DecisionInDecision.json
@@ -40,7 +40,7 @@
                   "taskReferenceName": "send_notification_subworkflow",
                   "description": "{\"description\":null}",
                   "inputParameters": {
-                    "customer_id": "${workflow.input.customer_id}"
+                    "id": "${workflow.input.customer_id}"
                   },
                   "type": "SUB_WORKFLOW",
                   "startDelay": 0,

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/OptionalTaskWorkflow.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/OptionalTaskWorkflow.json
@@ -14,7 +14,7 @@
       "taskReferenceName": "send_notification_subworkflow",
       "description": "{\"description\":null}",
       "inputParameters": {
-        "customer_id": "${workflow.input.customer_id}"
+        "id": "${workflow.input.customer_id}"
       },
       "type": "SUB_WORKFLOW",
       "dynamicTaskNameParam": null,

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/SendCustomerNotification.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/SendCustomerNotification.cs
@@ -5,6 +5,7 @@ namespace ConductorSharp.Engine.Tests.Samples.Workflows;
 #region models
 public class SendCustomerNotificationInput : WorkflowInput<SendCustomerNotificationOutput>
 {
+    [JsonProperty("id")]
     public int CustomerId { get; set; }
 }
 

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/SendCustomerNotification.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/SendCustomerNotification.json
@@ -14,7 +14,7 @@
       "taskReferenceName": "get_customer",
       "description": "{\"description\":null}",
       "inputParameters": {
-        "customer_id": "${workflow.input.customer_id}"
+        "id": "${workflow.input.customer_id}"
       },
       "type": "SIMPLE",
       "dynamicTaskNameParam": null,

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/SendCustomerNotification.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/SendCustomerNotification.json
@@ -14,7 +14,7 @@
       "taskReferenceName": "get_customer",
       "description": "{\"description\":null}",
       "inputParameters": {
-        "id": "${workflow.input.customer_id}"
+        "id": "${workflow.input.id}"
       },
       "type": "SIMPLE",
       "dynamicTaskNameParam": null,
@@ -77,7 +77,7 @@
     }
   ],
   "inputParameters": [
-    "{\"customer_id\":{\"value\":\"\",\"description\":\" (optional)\"}}"
+    "{\"id\":{\"value\":\"\",\"description\":\" (optional)\"}}"
   ],
   "outputParameters": null,
   "failureWorkflow": null,


### PR DESCRIPTION
`TaskDefinitionBuilder` and `WorkflowDefinitionBuilder` did not respect JsonProperty attributes. 
Before this PR it was possible that workflows built using scaffolded models contain invalid property names for tasks and workflows which have JsonProperty applied to those properties.

Also, Netwonsoft.Json snake case implementation will be used from now on when no attribute is applied (in order to ensure consistency between generated workflow/task object and workflow/task input/output model).