### PR TITLE
Use version set through SetOptions as fallback value

### DIFF
--- a/src/ConductorSharp.Engine/Builders/WorkflowDefinitionBuilder.cs
+++ b/src/ConductorSharp.Engine/Builders/WorkflowDefinitionBuilder.cs
@@ -86,7 +86,8 @@ namespace ConductorSharp.Engine.Builders
             var ownerEmail = _workflowType.GetDocSection("ownerEmail");
             var labels = _workflowType.GetDocSection("labels");
 
-            BuildContext.WorkflowOptions.Version = _workflowType.GetCustomAttribute<VersionAttribute>()?.Version ?? 1;
+            BuildContext.WorkflowOptions.Version =
+                _workflowType.GetCustomAttribute<VersionAttribute>()?.Version ?? BuildContext.WorkflowOptions.Version;
             BuildContext.Inputs = new();
 
             if (!string.IsNullOrEmpty(summary))

--- a/src/ConductorSharp.Engine/Util/WorkflowOptions.cs
+++ b/src/ConductorSharp.Engine/Util/WorkflowOptions.cs
@@ -11,7 +11,7 @@ namespace ConductorSharp.Engine.Util
 
         private readonly static Regex _labelRegex = new(_labelRegexString);
 
-        private int _version;
+        private int _version = 1;
         private string _description;
         private string[] _labels;
         private string _ownerApp;


### PR DESCRIPTION
If the workflow has no Version attribute set then fallback to value already set using SetOptions method(or 1 if SetOptions was not invoked at all).