### PR TITLE
support JsonPropertyName attribute

### DIFF
--- a/src/ConductorSharp.Engine/Util/NamingUtil.cs
+++ b/src/ConductorSharp.Engine/Util/NamingUtil.cs
@@ -3,6 +3,7 @@ using System;
 using System.Reflection;
 using ConductorSharp.Client;
 using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace ConductorSharp.Engine.Util
 {
@@ -34,6 +35,7 @@ namespace ConductorSharp.Engine.Util
         internal static string GetParameterName(PropertyInfo propInfo) =>
             propInfo.GetDocSection("originalName")
             ?? propInfo.GetCustomAttribute<JsonPropertyAttribute>(true)?.PropertyName
+            ?? propInfo.GetCustomAttribute<JsonPropertyNameAttribute>(true)?.Name
             ?? ConductorConstants.IoNamingStrategy.GetPropertyName(propInfo.Name, false);
     }
 }


### PR DESCRIPTION
This allows mixing System.Text and Newtonsoft.Json, i am not sure this is a good thing, but happens that I/O models contain classes that contain these attributes and the user has no control over them