### PR TITLE
support jsondocument serialization

### DIFF
--- a/src/ConductorSharp.Client/ConductorConstants.cs
+++ b/src/ConductorSharp.Client/ConductorConstants.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using ConductorSharp.Client.Util;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
 namespace ConductorSharp.Client
@@ -9,15 +10,24 @@ namespace ConductorSharp.Client
 
         public static NamingStrategy IoNamingStrategy { get; } = new SnakeCaseNamingStrategy();
 
-        public static JsonSerializer IoJsonSerializer { get; } =
-            new()
+        public static JsonSerializer IoJsonSerializer
+        {
+            get
             {
-                ContractResolver = new DefaultContractResolver { NamingStrategy = IoNamingStrategy },
-                NullValueHandling = NullValueHandling.Ignore,
-                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                MetadataPropertyHandling = MetadataPropertyHandling.ReadAhead,
-                TypeNameHandling = TypeNameHandling.Auto
-            };
+                var serializer = new JsonSerializer()
+                {
+                    ContractResolver = new DefaultContractResolver { NamingStrategy = IoNamingStrategy },
+                    NullValueHandling = NullValueHandling.Ignore,
+                    ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                    MetadataPropertyHandling = MetadataPropertyHandling.ReadAhead,
+                    TypeNameHandling = TypeNameHandling.Auto
+                };
+
+                serializer.Converters.Add(new JsonDocumentConverter());
+                return serializer;
+            }
+        }
+
         public static JsonSerializer DefinitionsSerializer { get; } = new() { NullValueHandling = NullValueHandling.Ignore };
     }
 }

--- a/src/ConductorSharp.Client/ConductorSharp.Client.csproj
+++ b/src/ConductorSharp.Client/ConductorSharp.Client.csproj
@@ -6,7 +6,7 @@
 		<Authors>Codaxy</Authors>
 		<Company>Codaxy</Company>
 		<PackageId>ConductorSharp.Client</PackageId>
-		<Version>2.1.3</Version>
+		<Version>2.1.4</Version>
 		<Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 		<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 		<PackageTags>netflix;conductor</PackageTags>

--- a/src/ConductorSharp.Client/Util/JsonDocumentConverter.cs
+++ b/src/ConductorSharp.Client/Util/JsonDocumentConverter.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Text.Json;
+
+namespace ConductorSharp.Client.Util
+{
+    public class JsonDocumentConverter : JsonConverter<JsonDocument>
+    {
+        public override void WriteJson(JsonWriter writer, JsonDocument value, Newtonsoft.Json.JsonSerializer serializer) =>
+            writer.WriteRawValue(value.RootElement.GetRawText());
+
+        public override JsonDocument ReadJson(
+            JsonReader reader,
+            Type objectType,
+            JsonDocument existingValue,
+            bool hasExistingValue,
+            Newtonsoft.Json.JsonSerializer serializer
+        ) => JsonDocument.Parse(JToken.FromObject(reader.Value).ToString());
+    }
+}

--- a/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
+++ b/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
@@ -6,7 +6,7 @@
     <Authors>Codaxy</Authors>
 	<Company>Codaxy</Company>
 	<PackageId>ConductorSharp.Engine</PackageId>
-	<Version>2.1.3</Version>
+	<Version>2.1.4</Version>
     <Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 	<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 	<PackageTags>netflix;conductor</PackageTags>

--- a/test/ConductorSharp.Engine.Tests/Unit/SerializationTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Unit/SerializationTests.cs
@@ -1,0 +1,37 @@
+﻿using ConductorSharp.Client;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace ConductorSharp.Engine.Tests.Unit
+{
+    public class SerializationTests
+    {
+        public class User
+        {
+            public JsonDocument JDocIdentity { get; set; }
+            public JObject JobjIdentity { get; set; }
+            public int Id { get; set; }
+        }
+
+        [Fact]
+        public void HandlesJsonDocumentDeserialization()
+        {
+            var user = new User { Id = 1 };
+            var anon = new { Name = "TestName", Surname = "TestSurname" };
+
+            user.JDocIdentity = System.Text.Json.JsonSerializer.SerializeToDocument(anon);
+            user.JobjIdentity = JObject.FromObject(anon);
+
+            var job = JObject.FromObject(user, ConductorConstants.IoJsonSerializer);
+            var userDeserialized = job.ToObject<User>(ConductorConstants.IoJsonSerializer);
+
+            Assert.NotNull(userDeserialized);
+            Assert.Equal(userDeserialized.JDocIdentity.RootElement.ToString(), userDeserialized.JobjIdentity.ToString(Formatting.None));
+        }
+    }
+}


### PR DESCRIPTION
Some users try to serialize JsonDocument. Since we use Newtonsoft json some changes are required to make this work (specifically creating a converter)