### PR TITLE
Add support for default values

### DIFF
--- a/src/ConductorSharp.Engine/Builders/WorkflowDefinitionBuilder.cs
+++ b/src/ConductorSharp.Engine/Builders/WorkflowDefinitionBuilder.cs
@@ -108,6 +108,7 @@ namespace ConductorSharp.Engine.Builders
             foreach (var prop in props)
             {
                 var isRequired = prop.GetCustomAttribute<RequiredAttribute>();
+                var defaultValue = prop.GetCustomAttribute<DefaultValueAttribute>()?.DefaultValue ?? string.Empty;
                 var description = prop.GetDocSection("summary");
 
                 var propertyName = NamingUtil.GetParameterName(prop);
@@ -116,7 +117,7 @@ namespace ConductorSharp.Engine.Builders
                 BuildContext.Inputs.Add(
                     new JProperty(
                         propertyName,
-                        new JObject { new JProperty("value", ""), new JProperty("description", $"{description} {requiredString}"), }
+                        new JObject { new JProperty("value", defaultValue), new JProperty("description", $"{description} {requiredString}"), }
                     )
                 );
             }

--- a/src/ConductorSharp.Engine/Util/DefaultValueAttribute.cs
+++ b/src/ConductorSharp.Engine/Util/DefaultValueAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ConductorSharp.Engine.Util
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class DefaultValueAttribute : Attribute
+    {
+        internal object DefaultValue { get; }
+
+        public DefaultValueAttribute(object defaultValue) => DefaultValue = defaultValue;
+    }
+}

--- a/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
+++ b/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
@@ -15,6 +15,7 @@
     <None Remove="Samples\Workflows\CSharpLambdaWorkflow.json" />
     <None Remove="Samples\Workflows\DecisionInDecision.json" />
     <None Remove="Samples\Workflows\DecisionTask.json" />
+    <None Remove="Samples\Workflows\DefaultValueWorkflow.json" />
     <None Remove="Samples\Workflows\DynamicTask.json" />
     <None Remove="Samples\Workflows\HumanTask.json" />
     <None Remove="Samples\Workflows\IndexerWorkflow.json" />
@@ -33,6 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Samples\Workflows\DefaultValueWorkflow.json" />
     <EmbeddedResource Include="Samples\Workflows\HumanTask.json" />
     <EmbeddedResource Include="Samples\Workflows\WaitTask.json" />
     <EmbeddedResource Include="Samples\Workflows\CSharpLambdaWorkflow.json">

--- a/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
@@ -49,6 +49,7 @@ namespace ConductorSharp.Engine.Tests.Integration
             _containerBuilder.RegisterWorkflow<HumanTaskWorkflow>();
             _containerBuilder.RegisterWorkflow<WaitTaskWorkflow>();
             _containerBuilder.RegisterWorkflow<IndexerWorkflow>();
+            _containerBuilder.RegisterWorkflow<DefaultValueWorkflow>();
 
             _container = _containerBuilder.Build();
         }
@@ -236,6 +237,7 @@ namespace ConductorSharp.Engine.Tests.Integration
             Assert.Equal(expectedDefinition, definition);
         }
 
+        [Fact]
         public void BuilderReturnsCorrectDefinitionWaitTaskWorkflow()
         {
             var definition = GetDefinitionFromWorkflow<WaitTaskWorkflow>();
@@ -244,10 +246,20 @@ namespace ConductorSharp.Engine.Tests.Integration
             Assert.Equal(expectedDefinition, definition);
         }
 
+        [Fact]
         public void BuilderReturnsCorrectDefinitionIndexerWorkflow()
         {
             var definition = GetDefinitionFromWorkflow<IndexerWorkflow>();
             var expectedDefinition = EmbeddedFileHelper.GetLinesFromEmbeddedFile("~/Samples/Workflows/IndexerWorkflow.json");
+
+            Assert.Equal(expectedDefinition, definition);
+        }
+
+        [Fact]
+        public void BuilderReturnsCorrectDefinitionDefaultValueWorkflow()
+        {
+            var definition = GetDefinitionFromWorkflow<DefaultValueWorkflow>();
+            var expectedDefinition = EmbeddedFileHelper.GetLinesFromEmbeddedFile("~/Samples/Workflows/DefaultValueWorkflow.json");
 
             Assert.Equal(expectedDefinition, definition);
         }

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/DefaultValueWorkflow.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/DefaultValueWorkflow.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConductorSharp.Engine.Tests.Samples.Workflows
+{
+    public class DefaultValueWorkflowInput : WorkflowInput<DefaultValueWorkflowOutput>
+    {
+        [DefaultValue("Default name")]
+        public string Name { get; set; }
+
+        [DefaultValue("Default address")]
+        public string Address { get; set; }
+    }
+
+    public class DefaultValueWorkflowOutput : WorkflowOutput { }
+
+    public class DefaultValueWorkflow : Workflow<DefaultValueWorkflow, DefaultValueWorkflowInput, DefaultValueWorkflowOutput>
+    {
+        public EmailPrepareV1 PrepareEmail { get; set; }
+
+        public DefaultValueWorkflow(WorkflowDefinitionBuilder<DefaultValueWorkflow, DefaultValueWorkflowInput, DefaultValueWorkflowOutput> builder)
+            : base(builder) { }
+
+        public override void BuildDefinition()
+        {
+            _builder.AddTask(wf => wf.PrepareEmail, wf => new() { Name = wf.WorkflowInput.Name, Address = wf.WorkflowInput.Address });
+        }
+    }
+}

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/DefaultValueWorkflow.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/DefaultValueWorkflow.json
@@ -1,0 +1,58 @@
+{
+  "ownerApp": null,
+  "createTime": 0,
+  "updateTime": 0,
+  "createdBy": null,
+  "updatedBy": null,
+  "name": "default_value_workflow",
+  "description": "{\"description\":null,\"labels\":null}",
+  "version": 1,
+  "tasks": [
+    {
+      "queryExpression": null,
+      "name": "EMAIL_prepare",
+      "taskReferenceName": "prepare_email",
+      "description": "{\"description\":null}",
+      "inputParameters": {
+        "name": "${workflow.input.name}",
+        "address": "${workflow.input.address}"
+      },
+      "type": "SIMPLE",
+      "dynamicTaskNameParam": null,
+      "caseValueParam": null,
+      "caseExpression": null,
+      "expression": null,
+      "evaluatorType": null,
+      "scriptExpression": null,
+      "decisionCases": null,
+      "dynamicForkJoinTasksParam": null,
+      "dynamicForkTasksParam": null,
+      "dynamicForkTasksInputParamName": null,
+      "defaultCase": null,
+      "forkTasks": null,
+      "startDelay": 0,
+      "subWorkflowParam": null,
+      "joinOn": null,
+      "sink": null,
+      "optional": false,
+      "taskDefinition": null,
+      "rateLimited": false,
+      "defaultExclusiveJoinTask": null,
+      "asyncComplete": false,
+      "loopCondition": null,
+      "loopOver": null
+    }
+  ],
+  "inputParameters": [
+    "{\"name\":{\"value\":\"Default name\",\"description\":\" (optional)\"},\"address\":{\"value\":\"Default address\",\"description\":\" (optional)\"}}"
+  ],
+  "outputParameters": null,
+  "failureWorkflow": null,
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": true,
+  "ownerEmail": null,
+  "timeoutPolicy": null,
+  "timeoutSeconds": 0,
+  "variables": null
+}


### PR DESCRIPTION
Specifying default values which are embedded in workflow definition is now supported


```
public class DefaultValueWorkflowInput : WorkflowInput<DefaultValueWorkflowOutput>
{
    [DefaultValue("Default name")]
    public string Name { get; set; }

    [DefaultValue("Default address")]
    public string Address { get; set; }
}

public class DefaultValueWorkflowOutput : WorkflowOutput { }

public class DefaultValueWorkflow : Workflow<DefaultValueWorkflow, DefaultValueWorkflowInput, DefaultValueWorkflowOutput>
{
    public EmailPrepareV1 PrepareEmail { get; set; }

    public DefaultValueWorkflow(WorkflowDefinitionBuilder<DefaultValueWorkflow, DefaultValueWorkflowInput, DefaultValueWorkflowOutput> builder)
        : base(builder) { }

    public override void BuildDefinition()
    {
        _builder.AddTask(wf => wf.PrepareEmail, wf => new() { Name = wf.WorkflowInput.Name, Address = wf.WorkflowInput.Address });
    }
}
```