### PR TITLE
Support primitive type interpolation, support variadic string.Format

### DIFF
--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/StringInterpolation.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/StringInterpolation.cs
@@ -21,7 +21,8 @@ namespace ConductorSharp.Engine.Tests.Samples.Workflows
     [OriginalName("TEST_StringInterpolation")]
     public class StringInterpolation : Workflow<StringInterpolation, StringInterpolationInput, StringInterpolationOutput>
     {
-        public const string Constant = "Value";
+        public const string ConstantStr = "Value";
+        public const int ConstantPrimitive = 0;
 
         public StringInterpolation(WorkflowDefinitionBuilder<StringInterpolation, StringInterpolationInput, StringInterpolationOutput> builder)
             : base(builder) { }
@@ -35,7 +36,7 @@ namespace ConductorSharp.Engine.Tests.Samples.Workflows
                 wf =>
                     new()
                     {
-                        Address = $"{wf.WorkflowInput.FirstInput},{wf.WorkflowInput.SecondInput},{Constant}",
+                        Address = $"{wf.WorkflowInput.FirstInput},{wf.WorkflowInput.SecondInput},{ConstantStr},{ConstantPrimitive}",
                         Name = $"Workflow name: {NamingUtil.NameOf<StringInterpolation>()}"
                     }
             );

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/StringInterpolation.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/StringInterpolation.json
@@ -14,7 +14,7 @@
       "taskReferenceName": "email_prepare",
       "description": "{\"description\":null}",
       "inputParameters": {
-        "address": "${workflow.input.first_input},${workflow.input.second_input},Value",
+        "address": "${workflow.input.first_input},${workflow.input.second_input},Value,0",
         "name": "Workflow name: TEST_StringInterpolation"
       },
       "type": "SIMPLE",


### PR DESCRIPTION
Fixes #135 and adds support for interpolation with variadic `string.Format`