### PR TITLE
Add an ability to inject services into workflow

### DIFF
--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/WorkflowWithDependencies.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/WorkflowWithDependencies.cs
@@ -10,6 +10,8 @@ namespace ConductorSharp.Engine.Tests.Samples.Workflows
     {
         private readonly IConfigurationService _testService;
 
+        public CustomerGetV1 GetCustomer { get; set; }
+
         public WorkflowWithDependencies(
             IConfigurationService testService,
             WorkflowDefinitionBuilder<WorkflowWithDependencies, WorkflowWithDependenciesInput, WorkflowWithDependenciesOutput> builder
@@ -20,7 +22,7 @@ namespace ConductorSharp.Engine.Tests.Samples.Workflows
 
         public override void BuildDefinition()
         {
-            _b
+            _builder.AddTask(wf => wf.GetCustomer, wf => new() { CustomerId = _testService.GetValue<int>("CustomerId") });
         }
     }
 }

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/WorkflowWithDependencies.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/WorkflowWithDependencies.cs
@@ -1,0 +1,16 @@
+﻿using ConductorSharp.Engine.Tests.Util;
+
+namespace ConductorSharp.Engine.Tests.Samples.Workflows
+{
+    public class WorkflowWithDependenciesInput : WorkflowInput<WorkflowWithDependenciesOutput> { }
+
+    public class WorkflowWithDependenciesOutput : WorkflowOutput { }
+
+    public class WorkflowWithDependencies : Workflow<WorkflowWithDependencies, WorkflowWithDependenciesInput, WorkflowWithDependenciesOutput>
+    {
+        public WorkflowWithDependencies(
+            ITestService testService,
+            WorkflowDefinitionBuilder<WorkflowWithDependencies, WorkflowWithDependenciesInput, WorkflowWithDependenciesOutput> builder
+        ) : base(builder) { }
+    }
+}

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/WorkflowWithDependencies.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/WorkflowWithDependencies.cs
@@ -8,21 +8,21 @@ namespace ConductorSharp.Engine.Tests.Samples.Workflows
 
     public class WorkflowWithDependencies : Workflow<WorkflowWithDependencies, WorkflowWithDependenciesInput, WorkflowWithDependenciesOutput>
     {
-        private readonly IConfigurationService _testService;
+        private readonly IConfigurationService _configurationService;
 
         public CustomerGetV1 GetCustomer { get; set; }
 
         public WorkflowWithDependencies(
-            IConfigurationService testService,
+            IConfigurationService configurationService,
             WorkflowDefinitionBuilder<WorkflowWithDependencies, WorkflowWithDependenciesInput, WorkflowWithDependenciesOutput> builder
         ) : base(builder)
         {
-            _testService = testService;
+            _configurationService = configurationService;
         }
 
         public override void BuildDefinition()
         {
-            _builder.AddTask(wf => wf.GetCustomer, wf => new() { CustomerId = _testService.GetValue<int>("CustomerId") });
+            _builder.AddTask(wf => wf.GetCustomer, wf => new() { CustomerId = _configurationService.GetValue<int>("CustomerId") });
         }
     }
 }

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/WorkflowWithDependencies.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/WorkflowWithDependencies.cs
@@ -8,9 +8,19 @@ namespace ConductorSharp.Engine.Tests.Samples.Workflows
 
     public class WorkflowWithDependencies : Workflow<WorkflowWithDependencies, WorkflowWithDependenciesInput, WorkflowWithDependenciesOutput>
     {
+        private readonly IConfigurationService _testService;
+
         public WorkflowWithDependencies(
-            ITestService testService,
+            IConfigurationService testService,
             WorkflowDefinitionBuilder<WorkflowWithDependencies, WorkflowWithDependenciesInput, WorkflowWithDependenciesOutput> builder
-        ) : base(builder) { }
+        ) : base(builder)
+        {
+            _testService = testService;
+        }
+
+        public override void BuildDefinition()
+        {
+            _b
+        }
     }
 }

--- a/test/ConductorSharp.Engine.Tests/Unit/ContainerBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Unit/ContainerBuilderTests.cs
@@ -1,5 +1,6 @@
 ﻿using ConductorSharp.Engine.Extensions;
 using ConductorSharp.Engine.Tests.Samples.Workflows;
+using ConductorSharp.Engine.Tests.Util;
 using ConductorSharp.Engine.Util.Builders;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -67,6 +68,46 @@ namespace ConductorSharp.Engine.Tests.Unit
             var definitions = container.GetRequiredService<IEnumerable<WorkflowDefinition>>().ToList();
 
             Assert.True(definitions.All(a => a.OwnerApp == overrideValue));
+        }
+
+        [Fact]
+        public void ResolveWorkflowDependencies()
+        {
+            var builder = new ServiceCollection();
+            builder
+                .AddConductorSharp(baseUrl: "empty", apiPath: "empty")
+                .AddExecutionManager(
+                    maxConcurrentWorkers: 1,
+                    sleepInterval: 1,
+                    longPollInterval: 1,
+                    null,
+                    handlerAssemblies: typeof(ContainerBuilderTests).Assembly
+                );
+
+            builder.AddTransient<ITestService, TestService>();
+            builder.RegisterWorkflow<WorkflowWithDependencies>();
+            var container = builder.BuildServiceProvider();
+            var definitions = container.GetRequiredService<IEnumerable<WorkflowDefinition>>();
+            Assert.Contains(definitions, def => def.Name == NamingUtil.NameOf<WorkflowWithDependencies>());
+        }
+
+        [Fact]
+        public void FailsToResolveWorkflowDependencies()
+        {
+            var builder = new ServiceCollection();
+            builder
+                .AddConductorSharp(baseUrl: "empty", apiPath: "empty")
+                .AddExecutionManager(
+                    maxConcurrentWorkers: 1,
+                    sleepInterval: 1,
+                    longPollInterval: 1,
+                    null,
+                    handlerAssemblies: typeof(ContainerBuilderTests).Assembly
+                );
+
+            builder.RegisterWorkflow<WorkflowWithDependencies>();
+            var container = builder.BuildServiceProvider();
+            Assert.Throws<InvalidOperationException>(() => container.GetRequiredService<IEnumerable<WorkflowDefinition>>());
         }
     }
 }

--- a/test/ConductorSharp.Engine.Tests/Unit/ContainerBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Unit/ContainerBuilderTests.cs
@@ -84,7 +84,7 @@ namespace ConductorSharp.Engine.Tests.Unit
                     handlerAssemblies: typeof(ContainerBuilderTests).Assembly
                 );
 
-            builder.AddTransient<ITestService, TestService>();
+            builder.AddTransient<IConfigurationService, ConfigurationService>();
             builder.RegisterWorkflow<WorkflowWithDependencies>();
             var container = builder.BuildServiceProvider();
             var definitions = container.GetRequiredService<IEnumerable<WorkflowDefinition>>();

--- a/test/ConductorSharp.Engine.Tests/Util/ConfigurationService.cs
+++ b/test/ConductorSharp.Engine.Tests/Util/ConfigurationService.cs
@@ -1,0 +1,12 @@
+﻿namespace ConductorSharp.Engine.Tests.Util
+{
+    public interface IConfigurationService
+    {
+        T GetValue<T>(string key);
+    }
+
+    public class ConfigurationService : IConfigurationService
+    {
+        public T GetValue<T>(string key) => default;
+    }
+}

--- a/test/ConductorSharp.Engine.Tests/Util/TestService.cs
+++ b/test/ConductorSharp.Engine.Tests/Util/TestService.cs
@@ -1,0 +1,6 @@
+﻿namespace ConductorSharp.Engine.Tests.Util
+{
+    public interface ITestService { }
+
+    public class TestService : ITestService { }
+}

--- a/test/ConductorSharp.Engine.Tests/Util/TestService.cs
+++ b/test/ConductorSharp.Engine.Tests/Util/TestService.cs
@@ -1,6 +1,0 @@
-﻿namespace ConductorSharp.Engine.Tests.Util
-{
-    public interface ITestService { }
-
-    public class TestService : ITestService { }
-}


### PR DESCRIPTION
Add an ability to inject registered services into `Workflow` classes.
Example below:

```csharp
public class WorkflowWithDependencies : Workflow<WorkflowWithDependencies, WorkflowWithDependenciesInput, WorkflowWithDependenciesOutput>
{
    private readonly IConfigurationService _configurationService;

    public CustomerGetV1 GetCustomer { get; set; }

    public WorkflowWithDependencies(
        IConfigurationService configurationService,
        WorkflowDefinitionBuilder<WorkflowWithDependencies, WorkflowWithDependenciesInput, WorkflowWithDependenciesOutput> builder
    ) : base(builder)
    {
        _configurationService = configurationService;
    }

    public override void BuildDefinition()
    {
        _builder.AddTask(wf => wf.GetCustomer, wf => new() { CustomerId = _configurationService.GetValue<int>("CustomerId") });
    }
}
```