### PR TITLE
Add attribute for renaming properties, remove support for Newtonsoft.Json and System.Text.Json attributes

### DIFF
--- a/examples/ConductorSharp.ApiEnabled/ConductorSharp.ApiEnabled.csproj
+++ b/examples/ConductorSharp.ApiEnabled/ConductorSharp.ApiEnabled.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ConductorSharp.Engine\ConductorSharp.Engine.csproj" />
+    <ProjectReference Include="..\..\src\ConductorSharp.Patterns\ConductorSharp.Patterns.csproj" />
   </ItemGroup>
 
 </Project>

--- a/examples/ConductorSharp.ApiEnabled/Extensions/ServiceCollectionExtensions.cs
+++ b/examples/ConductorSharp.ApiEnabled/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using ConductorSharp.ApiEnabled.Services;
 using ConductorSharp.Engine.Extensions;
 using ConductorSharp.Engine.Health;
+using ConductorSharp.Patterns.Extensions;
 using MediatR;
 
 namespace ConductorSharp.ApiEnabled.Extensions;
@@ -30,7 +31,8 @@ public static class ServiceCollectionExtensions
                 pipelines.AddContextLogging();
                 pipelines.AddRequestResponseLogging();
                 pipelines.AddValidation();
-            });
+            })
+            .AddConductorSharpPatterns();
 
         hostBuilder.AddSingleton<ITaskExecutionCounterService, TaskExecutionCounterService>();
         hostBuilder.RegisterWorkerTask<PrepareEmailHandler>(options =>

--- a/examples/ConductorSharp.Definitions/Workflows/HandleNotificationFailure.cs
+++ b/examples/ConductorSharp.Definitions/Workflows/HandleNotificationFailure.cs
@@ -13,7 +13,7 @@ namespace ConductorSharp.Definitions.Workflows
 {
     public class HandleNotificationFailureInput : WorkflowInput<HandleNotificationFailureOutput>
     {
-        [JsonProperty("workflowId")]
+        [PropertyName("workflowId")]
         public string WorkflowId { get; set; }
     }
 

--- a/src/ConductorSharp.Client/ConductorConstants.cs
+++ b/src/ConductorSharp.Client/ConductorConstants.cs
@@ -4,30 +4,12 @@ using Newtonsoft.Json.Serialization;
 
 namespace ConductorSharp.Client
 {
+    // TODO: Remove this class
     public static class ConductorConstants
     {
         public static string SimpleTask => "SIMPLE";
 
         public static NamingStrategy IoNamingStrategy { get; } = new SnakeCaseNamingStrategy();
-
-        public static JsonSerializer IoJsonSerializer
-        {
-            get
-            {
-                var serializer = new JsonSerializer()
-                {
-                    ContractResolver = new DefaultContractResolver { NamingStrategy = IoNamingStrategy },
-                    NullValueHandling = NullValueHandling.Ignore,
-                    ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                    MetadataPropertyHandling = MetadataPropertyHandling.ReadAhead,
-                    TypeNameHandling = TypeNameHandling.Auto
-                };
-
-                serializer.Converters.Add(new JsonValueConverter());
-                serializer.Converters.Add(new JsonDocumentConverter());
-                return serializer;
-            }
-        }
 
         public static JsonSerializer DefinitionsSerializer { get; } = new() { NullValueHandling = NullValueHandling.Ignore };
     }

--- a/src/ConductorSharp.Client/Service/ITaskService.cs
+++ b/src/ConductorSharp.Client/Service/ITaskService.cs
@@ -14,10 +14,10 @@ namespace ConductorSharp.Client.Service
         Task<JObject> TaskSearch(int size, string query);
         Task<IDictionary<string, int>> GetQueue(string name);
         Task<IDictionary<string, int>> GetAllQueues();
-        Task UpdateTaskCompleted(object outputData, string taskId, string workflowId);
+        Task UpdateTaskCompleted(JObject outputData, string taskId, string workflowId);
         Task UpdateTaskFailed(string taskId, string workflowId, string reasonForIncompletion);
         Task UpdateTaskFailed(string taskId, string workflowId, string reasonForIncompletion, string logMessage);
-        Task UpdateTaskFailed(object outputData, string taskId, string workflowId, string reasonForIncompletion, string logMessage);
+        Task UpdateTaskFailed(JObject outputData, string taskId, string workflowId, string reasonForIncompletion, string logMessage);
         Task<PollTaskResponse> PollTasks(string name, string workerId);
         Task<PollTaskResponse> PollTasks(string name, string workerId, string domain);
         Task<PollDataResponse[]> PollTaskQueueData(string taskType);

--- a/src/ConductorSharp.Client/Service/TaskService.cs
+++ b/src/ConductorSharp.Client/Service/TaskService.cs
@@ -47,12 +47,12 @@ namespace ConductorSharp.Client.Service
         public async Task<IDictionary<string, int>> GetAllQueues() =>
             await _client.ExecuteRequestAsync<IDictionary<string, int>>(ApiUrls.GetAllQueues(), HttpMethod.Get);
 
-        public Task UpdateTaskCompleted(object outputData, string taskId, string workflowId) =>
+        public Task UpdateTaskCompleted(JObject outputData, string taskId, string workflowId) =>
             UpdateTask(
                 new UpdateTaskRequest
                 {
                     Status = "COMPLETED",
-                    OutputData = JObject.FromObject(outputData, ConductorConstants.IoJsonSerializer),
+                    OutputData = outputData,
                     TaskId = taskId,
                     WorkflowInstanceId = workflowId
                 }
@@ -104,13 +104,13 @@ namespace ConductorSharp.Client.Service
         public Task<GetTaskLogsResponse[]> GetLogsForTask(string taskId) =>
             _client.ExecuteRequestAsync<GetTaskLogsResponse[]>(ApiUrls.GetLogsForTask(taskId), HttpMethod.Get);
 
-        public Task UpdateTaskFailed(object outputData, string taskId, string workflowId, string reasonForIncompletion, string logMessage) =>
+        public Task UpdateTaskFailed(JObject outputData, string taskId, string workflowId, string reasonForIncompletion, string logMessage) =>
             UpdateTask(
                 new UpdateTaskRequest
                 {
                     Status = "FAILED",
                     TaskId = taskId,
-                    OutputData = JObject.FromObject(outputData, ConductorConstants.IoJsonSerializer),
+                    OutputData = outputData,
                     WorkflowInstanceId = workflowId,
                     ReasonForIncompletion = reasonForIncompletion,
                     Logs = new List<LogData>

--- a/src/ConductorSharp.Engine/Model/TaskModel.cs
+++ b/src/ConductorSharp.Engine/Model/TaskModel.cs
@@ -1,4 +1,5 @@
 ﻿using ConductorSharp.Engine.Interface;
+using ConductorSharp.Engine.Util;
 using MediatR;
 using Newtonsoft.Json;
 
@@ -12,28 +13,28 @@ namespace ConductorSharp.Engine.Model
 
         public string Status { get; }
 
-        [JsonProperty("taskType")]
+        [PropertyName("taskType")]
         public string TaskType { get; }
 
-        [JsonProperty("startTime")]
+        [PropertyName("startTime")]
         public long StartTime { get; }
 
-        [JsonProperty("endTime")]
+        [PropertyName("endTime")]
         public long EndTime { get; }
 
-        [JsonProperty("taskId")]
+        [PropertyName("taskId")]
         public string TaskId { get; }
 
-        [JsonProperty("taskDefName")]
+        [PropertyName("taskDefName")]
         public string TaskDefName { get; }
 
-        [JsonProperty("scheduledTime")]
+        [PropertyName("scheduledTime")]
         public long ScheduledTime { get; }
 
-        [JsonProperty("referenceTaskName")]
+        [PropertyName("referenceTaskName")]
         public string ReferenceTaskName { get; }
 
-        [JsonProperty("correlationId")]
+        [PropertyName("correlationId")]
         public string CorrelationId { get; }
     }
 }

--- a/src/ConductorSharp.Engine/Model/TerminateTaskModel.cs
+++ b/src/ConductorSharp.Engine/Model/TerminateTaskModel.cs
@@ -15,10 +15,10 @@ namespace ConductorSharp.Engine.Model
 
     public class TerminateTaskInput : IRequest<NoOutput>
     {
-        [JsonProperty("workflowOutput")]
+        [PropertyName("workflowOutput")]
         public object WorkflowOutput { get; set; }
 
-        [JsonProperty("terminationStatus")]
+        [PropertyName("terminationStatus")]
         public TerminationStatus TerminationStatus { get; set; }
     }
 

--- a/src/ConductorSharp.Engine/Model/WaitTaskModel.cs
+++ b/src/ConductorSharp.Engine/Model/WaitTaskModel.cs
@@ -3,15 +3,16 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using ConductorSharp.Engine.Util;
 
 namespace ConductorSharp.Engine.Model
 {
     public class WaitTaskInput : IRequest<NoOutput>
     {
-        [JsonProperty("duration")]
+        [PropertyName("duration")]
         public string Duration { get; set; }
 
-        [JsonProperty("until")]
+        [PropertyName("until")]
         public string Until { get; set; }
     }
 

--- a/src/ConductorSharp.Engine/Util/IOContractResolver.cs
+++ b/src/ConductorSharp.Engine/Util/IOContractResolver.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace ConductorSharp.Engine.Util
+{
+    internal class IOContractResolver : DefaultContractResolver
+    {
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            // This property instantation is copied from base.CreateProperty source code, only addition is DeterminePropertyName
+            // This also means that other Newtonsoft.Json property attributes (like JsonIgnore) are ignored
+            var property = new JsonProperty
+            {
+                PropertyType = ((PropertyInfo)member).PropertyType,
+                DeclaringType = member.DeclaringType,
+                ValueProvider = CreateMemberValueProvider(member),
+                AttributeProvider = new ReflectionAttributeProvider(member),
+                UnderlyingName = member.Name,
+                PropertyName = DeterminePropertyName(member),
+                Readable = true,
+                Writable = true,
+            };
+
+            return property;
+        }
+
+        private string DeterminePropertyName(MemberInfo member)
+        {
+            var attributeMemberName = member.GetCustomAttribute<PropertyNameAttribute>()?.Name;
+            var nameToProcess = attributeMemberName ?? member.Name;
+            return NamingStrategy?.GetPropertyName(nameToProcess, attributeMemberName != null) ?? nameToProcess;
+        }
+    }
+}

--- a/src/ConductorSharp.Engine/Util/IOContractResolver.cs
+++ b/src/ConductorSharp.Engine/Util/IOContractResolver.cs
@@ -31,7 +31,7 @@ namespace ConductorSharp.Engine.Util
             {
                 PropertyInfo prop => prop.PropertyType,
                 FieldInfo field => field.FieldType,
-                _ => throw new NotSupportedException($"Unable to serializer MemberInfo type {member.GetType().Name}")
+                _ => throw new NotSupportedException($"Unable to serialize MemberInfo type {member.GetType().Name}")
             };
 
         private string DeterminePropertyName(MemberInfo member)

--- a/src/ConductorSharp.Engine/Util/IOContractResolver.cs
+++ b/src/ConductorSharp.Engine/Util/IOContractResolver.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -12,7 +13,7 @@ namespace ConductorSharp.Engine.Util
             // This also means that other Newtonsoft.Json property attributes (like JsonIgnore) are ignored
             var property = new JsonProperty
             {
-                PropertyType = ((PropertyInfo)member).PropertyType,
+                PropertyType = GetMemberType(member),
                 DeclaringType = member.DeclaringType,
                 ValueProvider = CreateMemberValueProvider(member),
                 AttributeProvider = new ReflectionAttributeProvider(member),
@@ -24,6 +25,14 @@ namespace ConductorSharp.Engine.Util
 
             return property;
         }
+
+        private Type GetMemberType(MemberInfo member) =>
+            member switch
+            {
+                PropertyInfo prop => prop.PropertyType,
+                FieldInfo field => field.FieldType,
+                _ => throw new NotSupportedException($"Unable to serializer MemberInfo type {member.GetType().Name}")
+            };
 
         private string DeterminePropertyName(MemberInfo member)
         {

--- a/src/ConductorSharp.Engine/Util/NamingUtil.cs
+++ b/src/ConductorSharp.Engine/Util/NamingUtil.cs
@@ -34,8 +34,7 @@ namespace ConductorSharp.Engine.Util
 
         internal static string GetParameterName(PropertyInfo propInfo) =>
             propInfo.GetDocSection("originalName")
-            ?? propInfo.GetCustomAttribute<JsonPropertyAttribute>(true)?.PropertyName
-            ?? propInfo.GetCustomAttribute<JsonPropertyNameAttribute>(true)?.Name
+            ?? propInfo.GetCustomAttribute<PropertyNameAttribute>(true)?.Name
             ?? ConductorConstants.IoNamingStrategy.GetPropertyName(propInfo.Name, false);
     }
 }

--- a/src/ConductorSharp.Engine/Util/PropertyNameAttribute.cs
+++ b/src/ConductorSharp.Engine/Util/PropertyNameAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ConductorSharp.Engine.Util
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class PropertyNameAttribute : Attribute
+    {
+        internal string Name { get; set; }
+
+        public PropertyNameAttribute(string name) => Name = name ?? throw new ArgumentNullException(nameof(name));
+    }
+}

--- a/src/ConductorSharp.Engine/Util/Serializers.cs
+++ b/src/ConductorSharp.Engine/Util/Serializers.cs
@@ -1,0 +1,27 @@
+﻿using ConductorSharp.Client.Util;
+using ConductorSharp.Client;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace ConductorSharp.Engine.Util
+{
+    public static class Serializers
+    {
+        static Serializers()
+        {
+            IOSerializer = new JsonSerializer
+            {
+                ContractResolver = new IOContractResolver { NamingStrategy = ConductorConstants.IoNamingStrategy },
+                NullValueHandling = NullValueHandling.Ignore,
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                MetadataPropertyHandling = MetadataPropertyHandling.ReadAhead,
+                TypeNameHandling = TypeNameHandling.Auto
+            };
+
+            IOSerializer.Converters.Add(new JsonValueConverter());
+            IOSerializer.Converters.Add(new JsonDocumentConverter());
+        }
+
+        public static JsonSerializer IOSerializer { get; }
+    }
+}

--- a/src/ConductorSharp.Patterns/Tasks/CSharpLambdaTask.cs
+++ b/src/ConductorSharp.Patterns/Tasks/CSharpLambdaTask.cs
@@ -23,11 +23,11 @@ namespace ConductorSharp.Patterns.Tasks
         public const string LambdaIdenfitierParamName = "lambda_identifier";
         public const string TaskInputParamName = "task_input";
 
-        [JsonProperty(LambdaIdenfitierParamName)]
+        [PropertyName(LambdaIdenfitierParamName)]
         [Required]
         public string LambdaIdentifier { get; set; }
 
-        [JsonProperty(TaskInputParamName)]
+        [PropertyName(TaskInputParamName)]
         [Required]
         public JObject TaskInput { get; set; }
     }

--- a/src/ConductorSharp.Patterns/Tasks/CSharpLambdaTask.cs
+++ b/src/ConductorSharp.Patterns/Tasks/CSharpLambdaTask.cs
@@ -50,9 +50,7 @@ namespace ConductorSharp.Patterns.Tasks
 
             try
             {
-                return Task.FromResult(
-                    lambda.Handler.DynamicInvoke(request.TaskInput.ToObject(lambda.TaskInputType, ConductorConstants.IoJsonSerializer))
-                );
+                return Task.FromResult(lambda.Handler.DynamicInvoke(request.TaskInput.ToObject(lambda.TaskInputType, Serializers.IOSerializer)));
             }
             catch (TargetInvocationException ex)
             {

--- a/test/ConductorSharp.Engine.Tests/Samples/Workers/GetCustomerHandler.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workers/GetCustomerHandler.cs
@@ -5,7 +5,7 @@ namespace ConductorSharp.Engine.Tests.Samples.Workers;
 public class GetCustomerRequest : IRequest<GetCustomerResponse>
 {
     [Required]
-    [JsonProperty("id")]
+    [PropertyName("id")]
     public int CustomerId { get; set; }
 }
 

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/SendCustomerNotification.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/SendCustomerNotification.cs
@@ -5,7 +5,7 @@ namespace ConductorSharp.Engine.Tests.Samples.Workflows;
 #region models
 public class SendCustomerNotificationInput : WorkflowInput<SendCustomerNotificationOutput>
 {
-    [JsonProperty("id")]
+    [PropertyName("id")]
     public int CustomerId { get; set; }
 }
 

--- a/test/ConductorSharp.Engine.Tests/Unit/SerializationTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Unit/SerializationTests.cs
@@ -26,8 +26,8 @@ namespace ConductorSharp.Engine.Tests.Unit
 
             user.JDocIdentity = JsonValue.Create(anon);
 
-            var job = JObject.FromObject(user, ConductorConstants.IoJsonSerializer);
-            var userDeserialized = job.ToObject<User>(ConductorConstants.IoJsonSerializer);
+            var job = JObject.FromObject(user, Serializers.IOSerializer);
+            var userDeserialized = job.ToObject<User>(Serializers.IOSerializer);
 
             Assert.NotNull(userDeserialized);
         }


### PR DESCRIPTION
Motivation:
- Using another library attribute for controlling behavior how properties are transformed during wf build phase does not make a lot of sense
- `JsonPropertyAttribute` also contains other properties that can affect behavior of serialization, user should not be allowed to control other aspects of serialization
- User should not care(and know) which serializer is used by the library. This feature will also allow us to easily swap `Newtonsoft.Json` for `System.Text.Json` if we decide to do it in future