### PR TITLE
Improve execution manager logging and parsing

### DIFF
--- a/src/ConductorSharp.Client/ConductorSharp.Client.csproj
+++ b/src/ConductorSharp.Client/ConductorSharp.Client.csproj
@@ -6,7 +6,7 @@
 		<Authors>Codaxy</Authors>
 		<Company>Codaxy</Company>
 		<PackageId>ConductorSharp.Client</PackageId>
-		<Version>2.3.1</Version>
+		<Version>2.4.0</Version>
 		<Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 		<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 		<PackageTags>netflix;conductor</PackageTags>

--- a/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
+++ b/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
@@ -6,7 +6,7 @@
     <Authors>Codaxy</Authors>
 	<Company>Codaxy</Company>
 	<PackageId>ConductorSharp.Engine</PackageId>
-	<Version>2.3.1</Version>
+	<Version>2.4.0</Version>
     <Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 	<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 	<PackageTags>netflix;conductor</PackageTags>

--- a/src/ConductorSharp.Engine/ExecutionManager.cs
+++ b/src/ConductorSharp.Engine/ExecutionManager.cs
@@ -118,6 +118,10 @@ namespace ConductorSharp.Engine
                 var inputType = GetInputType(scheduledWorker.TaskType);
                 var inputData = pollResponse.InputData.ToObject(inputType, ConductorConstants.IoJsonSerializer);
 
+                // Poll response data can be huge (if read from external storage)
+                // We can save memory by not holding reference to pollResponse.InputData after it is parsed
+                pollResponse.InputData = null;
+
                 using var scope = _lifetimeScope.BeginLifetimeScope();
 
                 var context = scope.ResolveOptional<ConductorSharpExecutionContext>();
@@ -141,8 +145,8 @@ namespace ConductorSharp.Engine
             catch (Exception exception)
             {
                 _logger.LogError(
-                    "{error} while executing {task} as part of {workflow} with id {workflowId}",
-                    exception.Message,
+                    "{@Exception} while executing {Task} as part of {Workflow} with id {WorkflowId}",
+                    exception,
                     pollResponse.TaskDefName,
                     pollResponse.WorkflowType,
                     pollResponse.WorkflowInstanceId

--- a/src/ConductorSharp.Patterns/ConductorSharp.Patterns.csproj
+++ b/src/ConductorSharp.Patterns/ConductorSharp.Patterns.csproj
@@ -6,7 +6,7 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Codaxy</Authors>
     <Company>Codaxy</Company>
-    <Version>2.3.1</Version>
+    <Version>2.4.0</Version>
   </PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Sometimes exceptions happen before the task handler is reached. In those cases, exception handling behavior won't be executed(which has detailed logging). This PR improves logging by logging all of the exception details(it is destructured).

Also, this task tries to optimize memory usage by removing references to potentially big input data in the execution manager.
I don't see any downside in doing this but we can not guarantee that GC will clean it immediately.