### PR TITLE
Add ability to specify task domain per task or all tasks in project

### DIFF
--- a/examples/ConductorSharp.ApiEnabled/appsettings.json
+++ b/examples/ConductorSharp.ApiEnabled/appsettings.json
@@ -1,6 +1,6 @@
 {
   "Conductor": {
-    "BaseUrl": "http://localhost:8081",
+    "BaseUrl": "http://localhost:8080",
     "LongPollInterval": 100,
     "MaxConcurrentWorkers": 10,
     "SleepInterval": 500

--- a/examples/ConductorSharp.Definitions/appsettings.json
+++ b/examples/ConductorSharp.Definitions/appsettings.json
@@ -1,6 +1,6 @@
 {
   "Conductor": {
-    "BaseUrl": "http://localhost:8081",
+    "BaseUrl": "http://localhost:8080",
     "LongPollInterval": 100,
     "MaxConcurrentWorkers": 10,
     "SleepInterval": 500

--- a/examples/ConductorSharp.NoApi/Handlers/PrepareEmailHandler.cs
+++ b/examples/ConductorSharp.NoApi/Handlers/PrepareEmailHandler.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ConductorSharp.Engine.Builders.Metadata;
+using ConductorSharp.Engine.Interface;
+using ConductorSharp.Engine.Util;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace ConductorSharp.NoApi.Handlers
+{
+    public class PrepareEmailRequest : IRequest<PrepareEmailResponse>
+    {
+        public string CustomerName { get; set; }
+        public string Address { get; set; }
+    }
+
+    public class PrepareEmailResponse
+    {
+        public string EmailBody { get; set; }
+    }
+
+    [OriginalName("EMAIL_prepare")]
+    [TaskDomain("my_domain")]
+    public class PrepareEmailHandler : ITaskRequestHandler<PrepareEmailRequest, PrepareEmailResponse>
+    {
+        private readonly ConductorSharpExecutionContext _context;
+        private readonly ILogger<PrepareEmailHandler> _logger;
+
+        public PrepareEmailHandler(ConductorSharpExecutionContext context, ILogger<PrepareEmailHandler> logger)
+        {
+            _context = context;
+            _logger = logger;
+        }
+
+        public async Task<PrepareEmailResponse> Handle(PrepareEmailRequest request, CancellationToken cancellationToken)
+        {
+            var emailBodyBuilder = new StringBuilder();
+
+            emailBodyBuilder.AppendLine("New order executed");
+            emailBodyBuilder.AppendLine("------------------");
+            emailBodyBuilder.AppendLine($"ProvisionDateTime: {DateTimeOffset.Now.ToString("r")}");
+            emailBodyBuilder.AppendLine($"Customer: {request.CustomerName}");
+            emailBodyBuilder.AppendLine($"Address: {request.Address}");
+            emailBodyBuilder.AppendLine("------------------");
+            emailBodyBuilder.AppendLine($"WorkflowId : {_context.WorkflowId}");
+            emailBodyBuilder.AppendLine($"WorkflowName: {_context.WorkflowName}");
+
+            _logger.LogInformation("Prepared email");
+
+            await Task.Delay(10000, cancellationToken);
+            return new PrepareEmailResponse { EmailBody = emailBodyBuilder.ToString() };
+        }
+    }
+}

--- a/examples/ConductorSharp.NoApi/Program.cs
+++ b/examples/ConductorSharp.NoApi/Program.cs
@@ -37,6 +37,7 @@ var builder = Host.CreateDefaultBuilder()
                 });
 
             services.RegisterWorkerTask<GetCustomerHandler>();
+            services.RegisterWorkerTask<PrepareEmailHandler>();
         }
     );
 

--- a/examples/ConductorSharp.NoApi/appsettings.json
+++ b/examples/ConductorSharp.NoApi/appsettings.json
@@ -1,6 +1,6 @@
 {
   "Conductor": {
-    "BaseUrl": "http://localhost:8081",
+    "BaseUrl": "http://localhost:8080",
     "LongPollInterval": 100,
     "MaxConcurrentWorkers": 10,
     "SleepInterval": 500

--- a/src/ConductorSharp.Engine/Builders/Metadata/TaskDomainAttribute.cs
+++ b/src/ConductorSharp.Engine/Builders/Metadata/TaskDomainAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace ConductorSharp.Engine.Builders.Metadata;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class TaskDomainAttribute(string domain) : Attribute
+{
+    internal string Domain { get; set; } = domain;
+}

--- a/src/ConductorSharp.Engine/Extensions/TaskRegistrationExtensions.cs
+++ b/src/ConductorSharp.Engine/Extensions/TaskRegistrationExtensions.cs
@@ -1,9 +1,11 @@
+using System;
+using System.Reflection;
 using ConductorSharp.Engine.Builders;
+using ConductorSharp.Engine.Builders.Metadata;
 using ConductorSharp.Engine.Interface;
 using ConductorSharp.Engine.Model;
 using ConductorSharp.Engine.Util.Builders;
 using Microsoft.Extensions.DependencyInjection;
-using System;
 
 namespace ConductorSharp.Engine.Extensions
 {
@@ -13,7 +15,8 @@ namespace ConductorSharp.Engine.Extensions
             this IServiceCollection builder,
             Action<TaskDefinitionOptions> updateOptions = null,
             BuildConfiguration buildConfiguration = null
-        ) where TWorkerTask : IWorker
+        )
+            where TWorkerTask : IWorker
         {
             builder.AddSingleton(ctx => ctx.ResolveTaskDefinitionBuilder(buildConfiguration).Build<TWorkerTask>(updateOptions));
 
@@ -22,7 +25,8 @@ namespace ConductorSharp.Engine.Extensions
                     new TaskToWorker
                     {
                         TaskName = ctx.ResolveTaskDefinitionBuilder(buildConfiguration).Build<TWorkerTask>(updateOptions).Name,
-                        TaskType = typeof(TWorkerTask)
+                        TaskType = typeof(TWorkerTask),
+                        TaskDomain = GetTaskDomain(typeof(TWorkerTask))
                     }
             );
         }
@@ -38,5 +42,7 @@ namespace ConductorSharp.Engine.Extensions
 
             return builder;
         }
+
+        private static string GetTaskDomain(Type workerType) => workerType.GetCustomAttribute<TaskDomainAttribute>()?.Domain;
     }
 }

--- a/src/ConductorSharp.Engine/Model/TaskToWorker.cs
+++ b/src/ConductorSharp.Engine/Model/TaskToWorker.cs
@@ -6,5 +6,6 @@ namespace ConductorSharp.Engine.Model
     {
         public string TaskName { get; set; }
         public Type TaskType { get; set; }
+        public string TaskDomain { get; set; }
     }
 }


### PR DESCRIPTION
Added an ability to poll tasks in certain domain.
This is achieved using the `TaskDomain` attribute.

```csharp
 [OriginalName("EMAIL_prepare")]
    [TaskDomain("my_domain")]
    public class PrepareEmailHandler : ITaskRequestHandler<PrepareEmailRequest, PrepareEmailResponse>
    {
        private readonly ConductorSharpExecutionContext _context;
        private readonly ILogger<PrepareEmailHandler> _logger;

        public PrepareEmailHandler(ConductorSharpExecutionContext context, ILogger<PrepareEmailHandler> logger)
        {
            _context = context;
            _logger = logger;
        }

        public async Task<PrepareEmailResponse> Handle(PrepareEmailRequest request, CancellationToken cancellationToken)
        {
            var emailBodyBuilder = new StringBuilder();

            emailBodyBuilder.AppendLine("New order executed");
            emailBodyBuilder.AppendLine("------------------");
            emailBodyBuilder.AppendLine($"ProvisionDateTime: {DateTimeOffset.Now.ToString("r")}");
            emailBodyBuilder.AppendLine($"Customer: {request.CustomerName}");
            emailBodyBuilder.AppendLine($"Address: {request.Address}");
            emailBodyBuilder.AppendLine("------------------");
            emailBodyBuilder.AppendLine($"WorkflowId : {_context.WorkflowId}");
            emailBodyBuilder.AppendLine($"WorkflowName: {_context.WorkflowName}");

            _logger.LogInformation("Prepared email");

            await Task.Delay(10000, cancellationToken);
            return new PrepareEmailResponse { EmailBody = emailBodyBuilder.ToString() };
        }
    }
```

Also user has ability to specify domain for all tasks in project during the ConductorSharp registration.
`TaskDomain` attribute has precedence over the global configuration.