### PR TITLE
Add support for event tasks

### DIFF
--- a/src/ConductorSharp.Engine/Builders/EventTaskBuilder.cs
+++ b/src/ConductorSharp.Engine/Builders/EventTaskBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using ConductorSharp.Client.Generated;
+using ConductorSharp.Engine.Interface;
+using ConductorSharp.Engine.Model;
+using ConductorSharp.Engine.Util.Builders;
+using MediatR;
+
+namespace ConductorSharp.Engine.Builders
+{
+    public static class EventTaskExtensions
+    {
+        public static ITaskOptionsBuilder AddTask<TWorkflow, TInput>(
+            this ITaskSequenceBuilder<TWorkflow> builder,
+            Expression<Func<TWorkflow, EventTaskModel<TInput>>> reference,
+            Expression<Func<TWorkflow, TInput>> input,
+            string sink
+        )
+            where TWorkflow : ITypedWorkflow
+            where TInput : IRequest<EventTaskModelOutput>
+        {
+            var taskBuilder = new EventTaskBuilder(reference.Body, input.Body, builder.BuildConfiguration, sink);
+            builder.AddTaskBuilderToSequence(taskBuilder);
+            return taskBuilder;
+        }
+    }
+
+    internal class EventTaskBuilder(Expression taskExpression, Expression inputExpression, BuildConfiguration buildConfiguration, string sink)
+        : BaseTaskBuilder<TerminateTaskInput, NoOutput>(taskExpression, inputExpression, buildConfiguration)
+    {
+        public override WorkflowTask[] Build() =>
+            [
+                new()
+                {
+                    Name = $"EVENT_{_taskRefferenceName}",
+                    TaskReferenceName = _taskRefferenceName,
+                    WorkflowTaskType = WorkflowTaskType.EVENT,
+                    Type = WorkflowTaskType.EVENT.ToString(),
+                    InputParameters = _inputParameters.ToObject<IDictionary<string, object>>(),
+                    Sink = sink
+                }
+            ];
+    }
+}

--- a/src/ConductorSharp.Engine/Model/EventTaskModel.cs
+++ b/src/ConductorSharp.Engine/Model/EventTaskModel.cs
@@ -1,0 +1,31 @@
+﻿using MediatR;
+using Newtonsoft.Json;
+
+namespace ConductorSharp.Engine.Model;
+
+public class EventTaskModelOutput
+{
+    [JsonProperty("workflowInstanceId")]
+    public string WorkflowInstanceId { get; set; }
+
+    [JsonProperty("workflowType")]
+    public string WorkflowType { get; set; }
+
+    [JsonProperty("workflowVersion")]
+    public int WorkflowVersion { get; set; }
+
+    [JsonProperty("correlationId")]
+    public string CorrelationId { get; set; }
+
+    [JsonProperty("sink")]
+    public string Sink { get; set; }
+
+    [JsonProperty("asyncComplete")]
+    public string AsyncComplete { get; set; }
+
+    [JsonProperty("event_produced")]
+    public string EventProduced { get; set; }
+}
+
+public class EventTaskModel<TInput> : TaskModel<TInput, EventTaskModelOutput>
+    where TInput : IRequest<EventTaskModelOutput> { }

--- a/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
+++ b/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
@@ -18,6 +18,7 @@
     <None Remove="Samples\Workflows\DecisionTask.json" />
     <None Remove="Samples\Workflows\DynamicTask.json" />
     <None Remove="Samples\Workflows\EvaluateExpressionWorkflow.json" />
+    <None Remove="Samples\Workflows\EventTaskWorkflow.json" />
     <None Remove="Samples\Workflows\HumanTask.json" />
     <None Remove="Samples\Workflows\IndexerWorkflow.json" />
     <None Remove="Samples\Workflows\ListInitializationWorkflow.json" />
@@ -68,6 +69,7 @@
 	<EmbeddedResource Include="Samples\Workflows\TerminateTaskWorkflow.json" />
 	<EmbeddedResource Include="Samples\Workflows\CastWorkflow.json" />
 	<EmbeddedResource Include="Samples\Workflows\VersionAttributeWorkflow.json" />
+	<EmbeddedResource Include="Samples\Workflows\EventTaskWorkflow.json" />
 	<EmbeddedResource Include="Samples\Workflows\WorkflowMetadataWorkflow.json" />
   </ItemGroup>
 

--- a/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
@@ -253,6 +253,15 @@ namespace ConductorSharp.Engine.Tests.Integration
             Assert.Equal(expectedDefinition, definition);
         }
 
+        [Fact]
+        public void BuilderReturnsCorrectDefinitionEventTaskWorkflow()
+        {
+            var definition = GetDefinitionFromWorkflow<EventTaskWorkflow>();
+            var expectedDefinition = EmbeddedFileHelper.GetLinesFromEmbeddedFile("~/Samples/Workflows/EventTaskWorkflow.json");
+
+            Assert.Equal(expectedDefinition, definition);
+        }
+
         private static string GetDefinitionFromWorkflow<TWorkflow>()
             where TWorkflow : IConfigurableWorkflow
         {

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/EventTaskWorkflow.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/EventTaskWorkflow.cs
@@ -1,0 +1,27 @@
+﻿using ConductorSharp.Engine.Builders.Metadata;
+
+namespace ConductorSharp.Engine.Tests.Samples.Workflows
+{
+    public class EventTaskWorkflowInput : WorkflowInput<EventTaskWorkflowOutput> { }
+
+    public class EventTaskWorkflowOutput : WorkflowOutput { }
+
+    [WorkflowMetadata(OwnerEmail = "test@test.com")]
+    public class EventTaskWorkflow : Workflow<EventTaskWorkflow, EventTaskWorkflowInput, EventTaskWorkflowOutput>
+    {
+        public class EventTaskPayload : IRequest<EventTaskModelOutput>
+        {
+            public string PayloadParam { get; set; }
+        }
+
+        public EventTaskModel<EventTaskPayload> EventTask { get; set; }
+
+        public EventTaskWorkflow(WorkflowDefinitionBuilder<EventTaskWorkflow, EventTaskWorkflowInput, EventTaskWorkflowOutput> builder)
+            : base(builder) { }
+
+        public override void BuildDefinition()
+        {
+            _builder.AddTask(wf => wf.EventTask, wf => new() { PayloadParam = "param" }, "conductor:event");
+        }
+    }
+}

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/EventTaskWorkflow.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/EventTaskWorkflow.json
@@ -1,0 +1,21 @@
+{
+  "name": "event_task_workflow",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "EVENT_event_task",
+      "taskReferenceName": "event_task",
+      "inputParameters": {
+        "payload_param": "param"
+      },
+      "type": "EVENT",
+      "sink": "conductor:event",
+      "workflowTaskType": "EVENT"
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {},
+  "schemaVersion": 2,
+  "ownerEmail": "test@test.com",
+  "timeoutSeconds": 0
+}


### PR DESCRIPTION
```csharp
[WorkflowMetadata(OwnerEmail = "test@test.com")]
public class EventTaskWorkflow : Workflow<EventTaskWorkflow, EventTaskWorkflowInput, EventTaskWorkflowOutput>
{
    public class EventTaskPayload : IRequest<EventTaskModelOutput>
    {
        public string PayloadParam { get; set; }
    }

    public EventTaskModel<EventTaskPayload> EventTask { get; set; }

    public EventTaskWorkflow(WorkflowDefinitionBuilder<EventTaskWorkflow, EventTaskWorkflowInput, EventTaskWorkflowOutput> builder)
        : base(builder) { }

    public override void BuildDefinition()
    {
        _builder.AddTask(wf => wf.EventTask, wf => new() { PayloadParam = "param" }, "conductor:event");
    }
}
```