### PR TITLE
Add support for alternate client

### DIFF
--- a/examples/ConductorSharp.ApiEnabled/Extensions/ServiceCollectionExtensions.cs
+++ b/examples/ConductorSharp.ApiEnabled/Extensions/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ public static class ServiceCollectionExtensions
     {
         hostBuilder
             .AddConductorSharp(baseUrl: configuration.GetValue<string>("Conductor:BaseUrl"))
+            .AddAlternateClient(baseUrl: configuration.GetValue<string>("Conductor:AlternateUrl"), "Alternate", "api/workflow", true)
             .AddExecutionManager(
                 maxConcurrentWorkers: configuration.GetValue<int>("Conductor:MaxConcurrentWorkers"),
                 sleepInterval: configuration.GetValue<int>("Conductor:SleepInterval"),

--- a/examples/ConductorSharp.ApiEnabled/appsettings.json
+++ b/examples/ConductorSharp.ApiEnabled/appsettings.json
@@ -1,6 +1,7 @@
 {
   "Conductor": {
     "BaseUrl": "http://localhost:8080",
+    "AlternateUrl": "https://fm-dev.10.7.6.124.nip.io",
     "LongPollInterval": 100,
     "MaxConcurrentWorkers": 10,
     "SleepInterval": 500

--- a/src/ConductorSharp.Client/ConductorSharp.Client.csproj
+++ b/src/ConductorSharp.Client/ConductorSharp.Client.csproj
@@ -6,7 +6,7 @@
 		<Authors>Codaxy</Authors>
 		<Company>Codaxy</Company>
 		<PackageId>ConductorSharp.Client</PackageId>
-		<Version>3.0.1-beta8</Version>
+		<Version>3.0.1-beta9</Version>
 		<Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 		<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 		<PackageTags>netflix;conductor</PackageTags>
@@ -17,6 +17,7 @@
 	</PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/src/ConductorSharp.Client/Service/AdminService.cs
+++ b/src/ConductorSharp.Client/Service/AdminService.cs
@@ -2,25 +2,27 @@
 
 namespace ConductorSharp.Client.Service
 {
-    public class AdminService(ConductorClient client) : IAdminService
+    public class AdminService(IHttpClientFactory httpClientFactory, string clientName) : IAdminService
     {
+        private readonly ConductorClient _client = new(httpClientFactory.CreateClient(clientName));
+
         public async Task<string> QueueRunningWorkflowsForSweepAsync(string workflowId, CancellationToken cancellationToken = default) =>
-            await client.RequeueSweepAsync(workflowId, cancellationToken);
+            await _client.RequeueSweepAsync(workflowId, cancellationToken);
 
         public async Task<string> VerifyAndRepairWorkflowConsistencyAsync(string workflowId, CancellationToken cancellationToken = default) =>
-            await client.VerifyAndRepairWorkflowConsistencyAsync(workflowId, cancellationToken);
+            await _client.VerifyAndRepairWorkflowConsistencyAsync(workflowId, cancellationToken);
 
         public async Task<ICollection<Generated.Task>> ListPendingTasksAsync(
             string taskType,
             int? start,
             int? count,
             CancellationToken cancellationToken = default
-        ) => await client.ViewAsync(taskType, start, count, cancellationToken);
+        ) => await _client.ViewAsync(taskType, start, count, cancellationToken);
 
         public async Task<IDictionary<string, object>> GetEventQueueMapAsync(bool? verbose, CancellationToken cancellationToken = default) =>
-            await client.GetEventQueuesAsync(verbose, cancellationToken);
+            await _client.GetEventQueuesAsync(verbose, cancellationToken);
 
         public async Task<IDictionary<string, object>> GetConfigMapAsync(CancellationToken cancellationToken = default) =>
-            await client.GetAllConfigAsync(cancellationToken);
+            await _client.GetAllConfigAsync(cancellationToken);
     }
 }

--- a/src/ConductorSharp.Client/Service/EventService.cs
+++ b/src/ConductorSharp.Client/Service/EventService.cs
@@ -3,24 +3,26 @@ using EventHandler = ConductorSharp.Client.Generated.EventHandler;
 
 namespace ConductorSharp.Client.Service
 {
-    public class EventService(ConductorClient client) : IEventService
+    public class EventService(IHttpClientFactory httpClientFactory, string clientName) : IEventService
     {
+        private readonly ConductorClient _client = new(httpClientFactory.CreateClient(clientName));
+
         public async Task<ICollection<EventHandler>> ListAsync(CancellationToken cancellationToken = default) =>
-            await client.GetEventHandlersAsync(cancellationToken);
+            await _client.GetEventHandlersAsync(cancellationToken);
 
         public async Task UpdateAsync(EventHandler eventHandler, CancellationToken cancellationToken = default) =>
-            await client.UpdateEventHandlerAsync(eventHandler, cancellationToken);
+            await _client.UpdateEventHandlerAsync(eventHandler, cancellationToken);
 
         public async Task AddAsync(EventHandler eventHandler, CancellationToken cancellationToken = default) =>
-            await client.AddEventHandlerAsync(eventHandler, cancellationToken);
+            await _client.AddEventHandlerAsync(eventHandler, cancellationToken);
 
         public async Task<ICollection<EventHandler>> ListForEventAsync(
             string @event,
             bool? activeOnly = null,
             CancellationToken cancellationToken = default
-        ) => await client.GetEventHandlersForEventAsync(@event, activeOnly, cancellationToken);
+        ) => await _client.GetEventHandlersForEventAsync(@event, activeOnly, cancellationToken);
 
         public async Task RemoveEventHandlerStatusAsync(string name, CancellationToken cancellationToken = default) =>
-            await client.RemoveEventHandlerStatusAsync(name, cancellationToken);
+            await _client.RemoveEventHandlerStatusAsync(name, cancellationToken);
     }
 }

--- a/src/ConductorSharp.Client/Service/ExternalPayloadService.cs
+++ b/src/ConductorSharp.Client/Service/ExternalPayloadService.cs
@@ -1,10 +1,13 @@
-﻿using ConductorSharp.Client.Generated;
+﻿using System.Net.Http;
+using ConductorSharp.Client.Generated;
 
 namespace ConductorSharp.Client.Service
 {
-    public class ExternalPayloadService(ConductorClient client) : IExternalPayloadService
+    public class ExternalPayloadService(IHttpClientFactory httpClientFactory, string clientName) : IExternalPayloadService
     {
+        private readonly ConductorClient _client = new(httpClientFactory.CreateClient(clientName));
+
         public async Task<FileResponse> GetExternalStorageDataAsync(string externalPayloadPath, CancellationToken cancellationToken = default) =>
-            await client.GetExternalStorageDataAsync(externalPayloadPath, cancellationToken);
+            await _client.GetExternalStorageDataAsync(externalPayloadPath, cancellationToken);
     }
 }

--- a/src/ConductorSharp.Client/Service/HealthService.cs
+++ b/src/ConductorSharp.Client/Service/HealthService.cs
@@ -1,12 +1,13 @@
-﻿using ConductorSharp.Client.Generated;
+﻿using System.Net.Http;
+using ConductorSharp.Client.Generated;
 
 namespace ConductorSharp.Client.Service
 {
-    public class HealthService(ConductorClient client) : IHealthService
+    public class HealthService(IHttpClientFactory httpClientFactory, string clientName) : IHealthService
     {
-        private readonly ConductorClient _conductorClient = client;
+        private readonly ConductorClient _client = new(httpClientFactory.CreateClient(clientName));
 
         public async Task<HealthCheckStatus> CheckHealthAsync(CancellationToken cancellationToken = default) =>
-            await _conductorClient.DoCheckAsync(cancellationToken);
+            await _client.DoCheckAsync(cancellationToken);
     }
 }

--- a/src/ConductorSharp.Client/Service/MetadataService.cs
+++ b/src/ConductorSharp.Client/Service/MetadataService.cs
@@ -2,45 +2,47 @@
 
 namespace ConductorSharp.Client.Service
 {
-    public class MetadataService(ConductorClient client) : IMetadataService
+    public class MetadataService(IHttpClientFactory httpClientFactory, string clientName) : IMetadataService
     {
+        private readonly ConductorClient _client = new(httpClientFactory.CreateClient(clientName));
+
         public async Task<ICollection<WorkflowDef>> ListWorkflowsAsync(CancellationToken cancellationToken = default) =>
-            await client.GetAllAsync(cancellationToken);
+            await _client.GetAllAsync(cancellationToken);
 
         public async Task<BulkResponse> UpdateWorkflowsAsync(IEnumerable<WorkflowDef> workflows, CancellationToken cancellationToken = default) =>
-            await client.UpdateAsync(workflows, cancellationToken);
+            await _client.UpdateAsync(workflows, cancellationToken);
 
         public async Task AddWorkflowAsync(WorkflowDef workflowDef, CancellationToken cancellationToken = default) =>
-            await client.CreateAsync(workflowDef, cancellationToken);
+            await _client.CreateAsync(workflowDef, cancellationToken);
 
         public async Task<ICollection<TaskDef>> ListTasksAsync(CancellationToken cancellationToken = default) =>
-            await client.GetTaskDefsAsync(cancellationToken);
+            await _client.GetTaskDefsAsync(cancellationToken);
 
         public async Task AddTaskAsync(TaskDef taskDef, CancellationToken cancellationToken = default) =>
-            await client.RegisterTaskDefAsync(taskDef, cancellationToken);
+            await _client.RegisterTaskDefAsync(taskDef, cancellationToken);
 
         public async Task AddTasksAsync(IEnumerable<TaskDef> taskDefs, CancellationToken cancellationToken = default) =>
-            await client.RegisterTaskDef_1Async(taskDefs, cancellationToken);
+            await _client.RegisterTaskDef_1Async(taskDefs, cancellationToken);
 
         public async Task ValidateWorkflowAsync(WorkflowDef workflowDef, CancellationToken cancellationToken = default) =>
-            await client.ValidateAsync(workflowDef, cancellationToken);
+            await _client.ValidateAsync(workflowDef, cancellationToken);
 
         public async Task<WorkflowDef> GetWorkflowAsync(string name, int? version = null, CancellationToken cancellationToken = default) =>
-            await client.GetAsync(name, version, cancellationToken);
+            await _client.GetAsync(name, version, cancellationToken);
 
         public async Task<IDictionary<string, object>> GetWorkflowNamesAndVersionsAsync(CancellationToken cancellationToken = default) =>
-            await client.GetWorkflowNamesAndVersionsAsync(cancellationToken);
+            await _client.GetWorkflowNamesAndVersionsAsync(cancellationToken);
 
         public async Task<ICollection<WorkflowDef>> GetAllWorkflowsWithLatestVersionsAsync(CancellationToken cancellationToken = default) =>
-            await client.GetAllWorkflowsWithLatestVersionsAsync(cancellationToken);
+            await _client.GetAllWorkflowsWithLatestVersionsAsync(cancellationToken);
 
         public async Task<TaskDef> GetTaskAsync(string taskType, CancellationToken cancellationToken = default) =>
-            await client.GetTaskDefAsync(taskType, cancellationToken);
+            await _client.GetTaskDefAsync(taskType, cancellationToken);
 
         public async Task DeleteTaskAsync(string taskType, CancellationToken cancellationToken = default) =>
-            await client.UnregisterTaskDefAsync(taskType, cancellationToken);
+            await _client.UnregisterTaskDefAsync(taskType, cancellationToken);
 
         public async Task DeleteWorkflowAsync(string name, int version, CancellationToken cancellationToken = default) =>
-            await client.UnregisterWorkflowDefAsync(name, version, cancellationToken);
+            await _client.UnregisterWorkflowDefAsync(name, version, cancellationToken);
     }
 }

--- a/src/ConductorSharp.Client/Service/QueueAdminService.cs
+++ b/src/ConductorSharp.Client/Service/QueueAdminService.cs
@@ -1,16 +1,19 @@
-﻿using ConductorSharp.Client.Generated;
+﻿using System.Net.Http;
+using ConductorSharp.Client.Generated;
 
 namespace ConductorSharp.Client.Service;
 
-public class QueueAdminService(ConductorClient client) : IQueueAdminService
+public class QueueAdminService(IHttpClientFactory httpClientFactory, string clientName) : IQueueAdminService
 {
+    private readonly ConductorClient _client = new(httpClientFactory.CreateClient(clientName));
+
     public async Task MarkWaitTaskCompletedAsync(
         string workflowId,
         string taskRefName,
         Status2 status,
         IDictionary<string, object> output,
         CancellationToken cancellationToken = default
-    ) => await client.Update_1Async(workflowId, taskRefName, status, output, cancellationToken);
+    ) => await _client.Update_1Async(workflowId, taskRefName, status, output, cancellationToken);
 
     public async Task MarkWaitTaskCompletedAsync(
         string workflowId,
@@ -18,11 +21,11 @@ public class QueueAdminService(ConductorClient client) : IQueueAdminService
         Generated.TaskStatus status,
         IDictionary<string, object> output,
         CancellationToken cancellationToken = default
-    ) => await client.UpdateByTaskIdAsync(workflowId, taskId, status, output, cancellationToken);
+    ) => await _client.UpdateByTaskIdAsync(workflowId, taskId, status, output, cancellationToken);
 
     public async Task<IDictionary<string, long>> GetQueueLengthAsync(CancellationToken cancellationToken = default) =>
-        await client.Size_1Async(cancellationToken);
+        await _client.Size_1Async(cancellationToken);
 
     public async Task<IDictionary<string, string>> GetQueueNamesAsync(CancellationToken cancellationToken = default) =>
-        await client.NamesAsync(cancellationToken);
+        await _client.NamesAsync(cancellationToken);
 }

--- a/src/ConductorSharp.Client/Service/TaskService.cs
+++ b/src/ConductorSharp.Client/Service/TaskService.cs
@@ -2,9 +2,9 @@
 
 namespace ConductorSharp.Client.Service
 {
-    public class TaskService(ConductorClient client) : ITaskService
+    public class TaskService(IHttpClientFactory httpClientFactory, string clientName) : ITaskService
     {
-        private readonly ConductorClient _client = client;
+        private readonly ConductorClient _client = new(httpClientFactory.CreateClient(clientName));
 
         public async Task<string> UpdateAsync(TaskResult updateRequest, CancellationToken cancellationToken = default) =>
             await _client.UpdateTaskAsync(updateRequest, cancellationToken);

--- a/src/ConductorSharp.Client/Service/WorkflowBulkService.cs
+++ b/src/ConductorSharp.Client/Service/WorkflowBulkService.cs
@@ -2,26 +2,28 @@
 
 namespace ConductorSharp.Client.Service;
 
-public class WorkflowBulkService(ConductorClient client) : IWorkflowBulkService
+public class WorkflowBulkService(IHttpClientFactory httpClientFactory, string clientName) : IWorkflowBulkService
 {
+    private readonly ConductorClient _client = new(httpClientFactory.CreateClient(clientName));
+
     public async Task<BulkResponse> ResumeAsync(IEnumerable<string> workflowIds, CancellationToken cancellationToken = default) =>
-        await client.ResumeWorkflow_1Async(workflowIds, cancellationToken);
+        await _client.ResumeWorkflow_1Async(workflowIds, cancellationToken);
 
     public async Task<BulkResponse> PauseAsync(IEnumerable<string> workflowIds, CancellationToken cancellationToken = default) =>
-        await client.PauseWorkflow_1Async(workflowIds, cancellationToken);
+        await _client.PauseWorkflow_1Async(workflowIds, cancellationToken);
 
     public async Task<BulkResponse> TerminateAsync(
         IEnumerable<string> worklowIds,
         string? reason = null,
         CancellationToken cancellationToken = default
-    ) => await client.TerminateAsync(reason, worklowIds, cancellationToken);
+    ) => await _client.TerminateAsync(reason, worklowIds, cancellationToken);
 
     public async Task<BulkResponse> RetryAsync(IEnumerable<string> workflowIds, CancellationToken cancellationToken = default) =>
-        await client.Retry_1Async(workflowIds, cancellationToken);
+        await _client.Retry_1Async(workflowIds, cancellationToken);
 
     public async Task<BulkResponse> RestartAsync(
         IEnumerable<string> workflowIds,
         bool? useLatestDefinition = null,
         CancellationToken cancellationToken = default
-    ) => await client.Restart_1Async(useLatestDefinition, workflowIds, cancellationToken);
+    ) => await _client.Restart_1Async(useLatestDefinition, workflowIds, cancellationToken);
 }

--- a/src/ConductorSharp.Client/Service/WorkflowService.cs
+++ b/src/ConductorSharp.Client/Service/WorkflowService.cs
@@ -1,10 +1,11 @@
-﻿using ConductorSharp.Client.Generated;
+﻿using System.Net.Http;
+using ConductorSharp.Client.Generated;
 
 namespace ConductorSharp.Client.Service
 {
-    public class WorkflowService(ConductorClient client) : IWorkflowService
+    public class WorkflowService(IHttpClientFactory httpClientFactory, string clientName) : IWorkflowService
     {
-        private readonly ConductorClient _client = client;
+        private readonly ConductorClient _client = new(httpClientFactory.CreateClient(clientName));
 
         /// <summary>
         /// Skips a given task from a current running workflow

--- a/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
+++ b/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
@@ -6,7 +6,7 @@
     <Authors>Codaxy</Authors>
 	<Company>Codaxy</Company>
 	<PackageId>ConductorSharp.Engine</PackageId>
-	<Version>3.0.1-beta8</Version>
+	<Version>3.0.1-beta9</Version>
     <Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 	<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 	<PackageTags>netflix;conductor</PackageTags>

--- a/src/ConductorSharp.Engine/Extensions/IConductorSharpBuilder.cs
+++ b/src/ConductorSharp.Engine/Extensions/IConductorSharpBuilder.cs
@@ -1,8 +1,8 @@
-﻿using ConductorSharp.Engine.Util.Builders;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
+using ConductorSharp.Engine.Util.Builders;
 
 namespace ConductorSharp.Engine.Extensions
 {
@@ -16,5 +16,6 @@ namespace ConductorSharp.Engine.Extensions
             params Assembly[] handlerAssemblies
         );
         IConductorSharpBuilder SetBuildConfiguration(BuildConfiguration buildConfiguration);
+        IConductorSharpBuilder AddAlternateClient(string baseUrl, string key, string apiPath = "api", bool ignoreInvalidCertificate = false);
     }
 }

--- a/src/ConductorSharp.Engine/Util/ApiPathOverrideHttpHandler.cs
+++ b/src/ConductorSharp.Engine/Util/ApiPathOverrideHttpHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,12 +8,19 @@ namespace ConductorSharp.Engine.Util
 {
     internal class ApiPathOverrideHttpHandler(string apiPath) : DelegatingHandler
     {
+        private readonly Regex _pathRegex = new("api");
+
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var uri = request.RequestUri!;
-            var overridenUri = new Uri(uri.ToString().Replace("api", apiPath));
-            request.RequestUri = overridenUri;
+            request.RequestUri = OverridePath(uri);
             return base.SendAsync(request, cancellationToken);
+        }
+
+        private Uri OverridePath(Uri uri)
+        {
+            var overridenPathAndQuery = _pathRegex.Replace(uri.PathAndQuery, apiPath, 1);
+            return new Uri(new Uri(uri.Scheme + "://" + uri.Authority), overridenPathAndQuery);
         }
     }
 }

--- a/src/ConductorSharp.Engine/Util/ApiPathOverrideHttpHandler.cs
+++ b/src/ConductorSharp.Engine/Util/ApiPathOverrideHttpHandler.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ConductorSharp.Engine.Util
+{
+    internal class ApiPathOverrideHttpHandler(string apiPath) : DelegatingHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var uri = request.RequestUri!;
+            var overridenUri = new Uri(uri.ToString().Replace("api", apiPath));
+            request.RequestUri = overridenUri;
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/src/ConductorSharp.Patterns/ConductorSharp.Patterns.csproj
+++ b/src/ConductorSharp.Patterns/ConductorSharp.Patterns.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Codaxy</Authors>
     <Company>Codaxy</Company>
-    <Version>3.0.1-beta8</Version>
+    <Version>3.0.1-beta9</Version>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/test/ConductorSharp.Engine.Tests/Unit/ContainerBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Unit/ContainerBuilderTests.cs
@@ -117,25 +117,15 @@ namespace ConductorSharp.Engine.Tests.Unit
             var metadataService = container.GetService<IMetadataService>();
             var workflowService = container.GetService<IWorkflowService>();
 
-            Assert.NotNull(adminService);
-            Assert.NotNull(eventService);
-            Assert.NotNull(externalPayloadService);
-            Assert.NotNull(queueAdminService);
-            Assert.NotNull(workflowBulkService);
-            Assert.NotNull(taskService);
-            Assert.NotNull(healthService);
-            Assert.NotNull(metadataService);
-            Assert.NotNull(workflowService);
-
-            adminService = container.GetKeyedService<IAdminService>(alternateClient);
-            eventService = container.GetKeyedService<IEventService>(alternateClient);
-            externalPayloadService = container.GetKeyedService<IExternalPayloadService>(alternateClient);
-            queueAdminService = container.GetKeyedService<IQueueAdminService>(alternateClient);
-            workflowBulkService = container.GetKeyedService<IWorkflowBulkService>(alternateClient);
-            taskService = container.GetKeyedService<ITaskService>(alternateClient);
-            healthService = container.GetKeyedService<IHealthService>(alternateClient);
-            metadataService = container.GetKeyedService<IMetadataService>(alternateClient);
-            workflowService = container.GetKeyedService<IWorkflowService>(alternateClient);
+            var alternateAdminService = container.GetKeyedService<IAdminService>(alternateClient);
+            var alternateEventService = container.GetKeyedService<IEventService>(alternateClient);
+            var alternateExternalPayloadService = container.GetKeyedService<IExternalPayloadService>(alternateClient);
+            var alternateQueueAdminService = container.GetKeyedService<IQueueAdminService>(alternateClient);
+            var alternateWorkflowBulkService = container.GetKeyedService<IWorkflowBulkService>(alternateClient);
+            var alternateTaskService = container.GetKeyedService<ITaskService>(alternateClient);
+            var alternateHealthService = container.GetKeyedService<IHealthService>(alternateClient);
+            var alternateMetadataService = container.GetKeyedService<IMetadataService>(alternateClient);
+            var alternateWorkflowService = container.GetKeyedService<IWorkflowService>(alternateClient);
 
             Assert.NotNull(adminService);
             Assert.NotNull(eventService);
@@ -146,6 +136,26 @@ namespace ConductorSharp.Engine.Tests.Unit
             Assert.NotNull(healthService);
             Assert.NotNull(metadataService);
             Assert.NotNull(workflowService);
+
+            Assert.NotNull(alternateAdminService);
+            Assert.NotNull(alternateEventService);
+            Assert.NotNull(alternateExternalPayloadService);
+            Assert.NotNull(alternateQueueAdminService);
+            Assert.NotNull(alternateWorkflowBulkService);
+            Assert.NotNull(alternateTaskService);
+            Assert.NotNull(alternateHealthService);
+            Assert.NotNull(alternateMetadataService);
+            Assert.NotNull(alternateWorkflowService);
+
+            Assert.NotEqual(adminService, alternateAdminService);
+            Assert.NotEqual(eventService, alternateEventService);
+            Assert.NotEqual(externalPayloadService, alternateExternalPayloadService);
+            Assert.NotEqual(queueAdminService, alternateQueueAdminService);
+            Assert.NotEqual(workflowBulkService, alternateWorkflowBulkService);
+            Assert.NotEqual(taskService, alternateTaskService);
+            Assert.NotEqual(healthService, alternateHealthService);
+            Assert.NotEqual(metadataService, alternateMetadataService);
+            Assert.NotEqual(workflowService, alternateWorkflowService);
         }
     }
 }

--- a/test/ConductorSharp.Engine.Tests/Unit/ContainerBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Unit/ContainerBuilderTests.cs
@@ -1,4 +1,5 @@
 ﻿using ConductorSharp.Client.Generated;
+using ConductorSharp.Client.Service;
 using ConductorSharp.Engine.Extensions;
 using ConductorSharp.Engine.Tests.Samples.Workflows;
 using ConductorSharp.Engine.Tests.Util;
@@ -95,6 +96,56 @@ namespace ConductorSharp.Engine.Tests.Unit
             builder.RegisterWorkflow<WorkflowWithDependencies>();
             var container = builder.BuildServiceProvider();
             Assert.Throws<InvalidOperationException>(() => container.GetRequiredService<IEnumerable<WorkflowDef>>());
+        }
+
+        [Fact]
+        public void SuccesfullyResolveClients()
+        {
+            const string alternateClient = "Alternate";
+            var builder = new ServiceCollection();
+            builder.AddConductorSharp(baseUrl: "http://empty/empty").AddAlternateClient("http://alternate/alternate", alternateClient);
+
+            var container = builder.BuildServiceProvider();
+
+            var adminService = container.GetService<IAdminService>();
+            var eventService = container.GetService<IEventService>();
+            var externalPayloadService = container.GetService<IExternalPayloadService>();
+            var queueAdminService = container.GetService<IQueueAdminService>();
+            var workflowBulkService = container.GetService<IWorkflowBulkService>();
+            var taskService = container.GetService<ITaskService>();
+            var healthService = container.GetService<IHealthService>();
+            var metadataService = container.GetService<IMetadataService>();
+            var workflowService = container.GetService<IWorkflowService>();
+
+            Assert.NotNull(adminService);
+            Assert.NotNull(eventService);
+            Assert.NotNull(externalPayloadService);
+            Assert.NotNull(queueAdminService);
+            Assert.NotNull(workflowBulkService);
+            Assert.NotNull(taskService);
+            Assert.NotNull(healthService);
+            Assert.NotNull(metadataService);
+            Assert.NotNull(workflowService);
+
+            adminService = container.GetKeyedService<IAdminService>(alternateClient);
+            eventService = container.GetKeyedService<IEventService>(alternateClient);
+            externalPayloadService = container.GetKeyedService<IExternalPayloadService>(alternateClient);
+            queueAdminService = container.GetKeyedService<IQueueAdminService>(alternateClient);
+            workflowBulkService = container.GetKeyedService<IWorkflowBulkService>(alternateClient);
+            taskService = container.GetKeyedService<ITaskService>(alternateClient);
+            healthService = container.GetKeyedService<IHealthService>(alternateClient);
+            metadataService = container.GetKeyedService<IMetadataService>(alternateClient);
+            workflowService = container.GetKeyedService<IWorkflowService>(alternateClient);
+
+            Assert.NotNull(adminService);
+            Assert.NotNull(eventService);
+            Assert.NotNull(externalPayloadService);
+            Assert.NotNull(queueAdminService);
+            Assert.NotNull(workflowBulkService);
+            Assert.NotNull(taskService);
+            Assert.NotNull(healthService);
+            Assert.NotNull(metadataService);
+            Assert.NotNull(workflowService);
         }
     }
 }


### PR DESCRIPTION
We want to have ability to access multiple instances of Conductor.
For that we should use `AddAlternateClient` method to register additional interfaces corresponding to another Conductor instance.

```csharp
hostBuilder
    .AddConductorSharp(baseUrl: configuration.GetValue<string>("Conductor:BaseUrl"))
    .AddAlternateClient(baseUrl: configuration.GetValue<string>("Conductor:AlternateUrl"), "Alternate", "api/workflow", true)
```
`AddAlternateClient` has following signature:

```csharp
IConductorSharpBuilder AddAlternateClient(string baseUrl, string key, string apiPath = "api", bool ignoreInvalidCertificate = false);
```
`key` is used with `[FromKeyedServices]` attribute to fetch additional client interfaces from DI container.

Example:

```csharp
public WorkflowController(
    IMetadataService metadataService,
    IWorkflowService workflowService,
    ITaskService taskService,
    [FromKeyedServices("Alternate")] IMetadataService alternateMetadataService
)
{
    _metadataService = metadataService;
    _workflowService = workflowService;
    _taskService = taskService;
    _alternateMetadataService = alternateMetadataService;
}
```
