### PR TITLE
Add ability to initialize property inputs of type IDictionary<string, object>

### DIFF
--- a/src/ConductorSharp.Client/ConductorSharp.Client.csproj
+++ b/src/ConductorSharp.Client/ConductorSharp.Client.csproj
@@ -6,7 +6,7 @@
 		<Authors>Codaxy</Authors>
 		<Company>Codaxy</Company>
 		<PackageId>ConductorSharp.Client</PackageId>
-		<Version>3.0.1-beta9</Version>
+		<Version>3.0.1-beta10</Version>
 		<Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 		<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 		<PackageTags>netflix;conductor</PackageTags>

--- a/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
+++ b/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
@@ -6,7 +6,7 @@
     <Authors>Codaxy</Authors>
 	<Company>Codaxy</Company>
 	<PackageId>ConductorSharp.Engine</PackageId>
-	<Version>3.0.1-beta9</Version>
+	<Version>3.0.1-beta10</Version>
     <Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 	<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 	<PackageTags>netflix;conductor</PackageTags>

--- a/src/ConductorSharp.Patterns/ConductorSharp.Patterns.csproj
+++ b/src/ConductorSharp.Patterns/ConductorSharp.Patterns.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Codaxy</Authors>
     <Company>Codaxy</Company>
-    <Version>3.0.1-beta9</Version>
+    <Version>3.0.1-beta10</Version>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
+++ b/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
@@ -16,6 +16,7 @@
     <None Remove="Samples\Workflows\CSharpLambdaWorkflow.json" />
     <None Remove="Samples\Workflows\DecisionInDecision.json" />
     <None Remove="Samples\Workflows\DecisionTask.json" />
+    <None Remove="Samples\Workflows\DictionaryInitializationWorkflow.json" />
     <None Remove="Samples\Workflows\DynamicTask.json" />
     <None Remove="Samples\Workflows\EvaluateExpressionWorkflow.json" />
     <None Remove="Samples\Workflows\EventTaskWorkflow.json" />
@@ -39,6 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Samples\Workflows\DictionaryInitializationWorkflow.json" />
     <EmbeddedResource Include="Samples\Workflows\HumanTaskWorkflow.json" />
     <EmbeddedResource Include="Samples\Workflows\ListInitializationWorkflow.json" />
     <EmbeddedResource Include="Samples\Workflows\EvaluateExpressionWorkflow.json" />

--- a/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
@@ -262,6 +262,15 @@ namespace ConductorSharp.Engine.Tests.Integration
             Assert.Equal(expectedDefinition, definition);
         }
 
+        [Fact]
+        public void BuilderReturnsCorrectDefinitionDictionaryInitializationWorkflow()
+        {
+            var definition = GetDefinitionFromWorkflow<DictionaryInitializationWorkflow>();
+            var expectedDefinition = EmbeddedFileHelper.GetLinesFromEmbeddedFile("~/Samples/Workflows/DictionaryInitializationWorkflow.json");
+
+            Assert.Equal(expectedDefinition, definition);
+        }
+
         private static string GetDefinitionFromWorkflow<TWorkflow>()
             where TWorkflow : IConfigurableWorkflow
         {

--- a/test/ConductorSharp.Engine.Tests/Samples/Tasks/DictionaryInputTask.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Tasks/DictionaryInputTask.cs
@@ -1,0 +1,10 @@
+﻿namespace ConductorSharp.Engine.Tests.Samples.Tasks;
+
+public class DictionaryInputTaskInput : IRequest<DictionaryInputTaskOutput>
+{
+    public IDictionary<string, object> Input { get; set; }
+}
+
+public class DictionaryInputTaskOutput;
+
+public class DictionaryInputTask : SimpleTaskModel<DictionaryInputTaskInput, DictionaryInputTaskOutput>;

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/DictionaryInitializationWorkflow.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/DictionaryInitializationWorkflow.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConductorSharp.Engine.Tests.Samples.Workflows
+{
+    public class DictionaryInitializationWorkflowInput : WorkflowInput<DictionaryInitializationWorkflowOutput> { }
+
+    public class DictionaryInitializationWorkflowOutput : WorkflowOutput { }
+
+    public class DictionaryInitializationWorkflow
+        : Workflow<DictionaryInitializationWorkflow, DictionaryInitializationWorkflowInput, DictionaryInitializationWorkflowOutput>
+    {
+        public DictionaryInitializationWorkflow(
+            WorkflowDefinitionBuilder<
+                DictionaryInitializationWorkflow,
+                DictionaryInitializationWorkflowInput,
+                DictionaryInitializationWorkflowOutput
+            > builder
+        )
+            : base(builder) { }
+
+        public DictionaryInputTask DictionaryTask { get; set; }
+
+        public override void BuildDefinition()
+        {
+            _builder.AddTask(
+                wf => wf.DictionaryTask,
+                wf =>
+                    new()
+                    {
+                        Input = new Dictionary<string, object>() { { "test1", "value" }, { "test2", new { MyProp = "test" } } }
+                    }
+            );
+        }
+    }
+}

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/DictionaryInitializationWorkflow.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/DictionaryInitializationWorkflow.json
@@ -1,0 +1,25 @@
+{
+  "name": "dictionary_initialization_workflow",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "dictionary_input_task",
+      "taskReferenceName": "dictionary_task",
+      "inputParameters": {
+        "input": {
+          "test1": "value",
+          "test2": {
+            "my_prop": "test"
+          }
+        }
+      },
+      "type": "SIMPLE",
+      "optional": false,
+      "workflowTaskType": "SIMPLE"
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {},
+  "schemaVersion": 2,
+  "timeoutSeconds": 0
+}

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/Workflow.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/Workflow.cs
@@ -1,0 +1,4 @@
+﻿namespace ConductorSharp.Engine.Tests.Samples.Workflows
+{
+    public class Workflow<T1, T2> { }
+}


### PR DESCRIPTION
From now on following is possible:

```csharp
_builder.AddTask(
    wf => wf.DictionaryTask,
    wf =>
        new()
        {
            Input = new Dictionary<string, object>() { { "test1", "value" }, { "test2", new { MyProp = "test" } } }
        }
```

where `Input` is of type `IDictionary<string, object>`