### PR TITLE
Change the cancellation detection strategy

### DIFF
--- a/src/ConductorSharp.Client/ConductorSharp.Client.csproj
+++ b/src/ConductorSharp.Client/ConductorSharp.Client.csproj
@@ -6,7 +6,7 @@
 		<Authors>Codaxy</Authors>
 		<Company>Codaxy</Company>
 		<PackageId>ConductorSharp.Client</PackageId>
-		<Version>3.4.0</Version>
+		<Version>3.4.1</Version>
 		<Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 		<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 		<PackageTags>netflix;conductor</PackageTags>

--- a/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
+++ b/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
@@ -6,7 +6,7 @@
     <Authors>Codaxy</Authors>
 	<Company>Codaxy</Company>
 	<PackageId>ConductorSharp.Engine</PackageId>
-	<Version>3.4.0</Version>
+	<Version>3.4.1</Version>
     <Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 	<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 	<PackageTags>netflix;conductor</PackageTags>

--- a/src/ConductorSharp.Engine/ExecutionManager.cs
+++ b/src/ConductorSharp.Engine/ExecutionManager.cs
@@ -222,6 +222,16 @@ namespace ConductorSharp.Engine
                     pollResponse.WorkflowInstanceId
                 );
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) // This is fine since we know cancellationToken comes from background service
+            {
+                _logger.LogWarning(
+                    "Cancelling task {Task}(id={TaskId}) of workflow {Workflow}(id={WorkflowId}) due to background service shutdown",
+                    pollResponse.TaskDefName,
+                    pollResponse.TaskId,
+                    pollResponse.WorkflowType,
+                    pollResponse.WorkflowInstanceId
+                );
+            }
             catch (Exception exception)
             {
                 _logger.LogError(

--- a/src/ConductorSharp.Engine/ExecutionManager.cs
+++ b/src/ConductorSharp.Engine/ExecutionManager.cs
@@ -140,21 +140,7 @@ namespace ConductorSharp.Engine
                 return;
             }
 
-            try
-            {
-                using var tokenHolder = _cancellationNotifier.GetCancellationToken(pollResponse.TaskId, cancellationToken);
-                await ProcessPolledTask(pollResponse, workerId, scheduledWorker, tokenHolder.CancellationToken);
-            }
-            catch (TaskCanceledException)
-            {
-                _logger.LogWarning(
-                    "Polled task {Task}(id={TaskId}) of workflow {Workflow}(id={WorkflowId}) is cancelled",
-                    pollResponse.TaskDefName,
-                    pollResponse.TaskId,
-                    pollResponse.WorkflowType,
-                    pollResponse.WorkflowInstanceId
-                );
-            }
+            await ProcessPolledTask(pollResponse, workerId, scheduledWorker, cancellationToken);
         }
 
         private async Task ProcessPolledTask(
@@ -164,6 +150,8 @@ namespace ConductorSharp.Engine
             CancellationToken cancellationToken
         )
         {
+            using var tokenHolder = _cancellationNotifier.GetCancellationToken(pollResponse.TaskId, cancellationToken);
+
             try
             {
                 if (!string.IsNullOrEmpty(pollResponse.ExternalInputPayloadStoragePath))
@@ -178,7 +166,7 @@ namespace ConductorSharp.Engine
                     );
 
                     // TODO: iffy
-                    var file = await _externalPayloadService.GetExternalStorageDataAsync(externalStorageLocation.Path, cancellationToken);
+                    var file = await _externalPayloadService.GetExternalStorageDataAsync(externalStorageLocation.Path, tokenHolder.CancellationToken);
 
                     using TextReader textReader = new StreamReader(file.Stream);
                     var json = await textReader.ReadToEndAsync();
@@ -211,7 +199,7 @@ namespace ConductorSharp.Engine
                     context.WorkerId = workerId;
                 }
 
-                var response = await mediator.Send(inputData, cancellationToken);
+                var response = await mediator.Send(inputData, tokenHolder.CancellationToken);
 
                 await _taskManager.UpdateAsync(
                     new TaskResult
@@ -221,13 +209,18 @@ namespace ConductorSharp.Engine
                         OutputData = SerializationHelper.ObjectToDictionary(response, ConductorConstants.IoJsonSerializerSettings),
                         WorkflowInstanceId = pollResponse.WorkflowInstanceId
                     },
-                    cancellationToken
+                    tokenHolder.CancellationToken
                 );
             }
-            catch (TaskCanceledException)
+            catch (OperationCanceledException) when (tokenHolder.IsCancellationRequestedByNotifier)
             {
-                // Propagate this exception to outer handler
-                throw;
+                _logger.LogWarning(
+                    "Polled task {Task}(id={TaskId}) of workflow {Workflow}(id={WorkflowId}) is cancelled",
+                    pollResponse.TaskDefName,
+                    pollResponse.TaskId,
+                    pollResponse.WorkflowType,
+                    pollResponse.WorkflowInstanceId
+                );
             }
             catch (Exception exception)
             {
@@ -256,10 +249,10 @@ namespace ConductorSharp.Engine
                                 OutputData = SerializationHelper.ObjectToDictionary(errorMessage, ConductorConstants.IoJsonSerializerSettings),
                                 WorkflowInstanceId = pollResponse?.WorkflowInstanceId
                             },
-                            cancellationToken
+                            tokenHolder.CancellationToken
                         ),
-                        _taskManager.LogAsync(pollResponse.TaskId, exception.Message, cancellationToken),
-                        _taskManager.LogAsync(pollResponse.TaskId, exception.StackTrace, cancellationToken)
+                        _taskManager.LogAsync(pollResponse.TaskId, exception.Message, tokenHolder.CancellationToken),
+                        _taskManager.LogAsync(pollResponse.TaskId, exception.StackTrace, tokenHolder.CancellationToken)
                     ]
                 );
             }

--- a/src/ConductorSharp.Engine/Interface/ICancellationNotifier.cs
+++ b/src/ConductorSharp.Engine/Interface/ICancellationNotifier.cs
@@ -8,6 +8,7 @@ namespace ConductorSharp.Engine.Interface
         public interface ICancellationTokenHolder : IDisposable
         {
             CancellationToken CancellationToken { get; }
+            bool IsCancellationRequestedByNotifier { get; }
         }
 
         ICancellationTokenHolder GetCancellationToken(string taskId, CancellationToken engineCancellationToken);

--- a/src/ConductorSharp.Engine/Service/NoOpCancellationNotifier.cs
+++ b/src/ConductorSharp.Engine/Service/NoOpCancellationNotifier.cs
@@ -10,6 +10,8 @@ internal class NoOpCancellationNotifier : ICancellationNotifier
     {
         public CancellationToken CancellationToken { get; } = cancellationToken;
 
+        public bool IsCancellationRequestedByNotifier => false;
+
         public void Dispose() { }
     }
 

--- a/src/ConductorSharp.KafkaCancellationNotifier/ConductorSharp.KafkaCancellationNotifier.csproj
+++ b/src/ConductorSharp.KafkaCancellationNotifier/ConductorSharp.KafkaCancellationNotifier.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.4.0</Version>
+    <Version>3.4.1</Version>
     <Authors>Codaxy</Authors>
     <Company>Codaxy</Company>
   </PropertyGroup>

--- a/src/ConductorSharp.Patterns/ConductorSharp.Patterns.csproj
+++ b/src/ConductorSharp.Patterns/ConductorSharp.Patterns.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Codaxy</Authors>
     <Company>Codaxy</Company>
-    <Version>3.4.0</Version>
+    <Version>3.4.1</Version>
   </PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Cancellation detection was primitive(i.e. cancellation was logged only if `TaskCancelledException` was thrown). This had several issues.

- Some libraries throw `OperationCancelledException` if the task is cancelled (hence why we now use `OperationCancelledException` instead of TaskCancelledException). Also `OperationCancelledException` is base of `TaskCancelledException` which means we can handle the later.
- We also want to make sure that cancellation request comes from Kafka topic(instead of someone just throwing `OperationCancelledException`) hence why we introduce additional condition.