### PR TITLE
Added the builder to support the do-while task type

### DIFF
--- a/src/ConductorSharp.Engine/Builders/DoWhileTaskBuilder.cs
+++ b/src/ConductorSharp.Engine/Builders/DoWhileTaskBuilder.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using ConductorSharp.Client.Generated;
+using ConductorSharp.Engine.Interface;
+using ConductorSharp.Engine.Model;
+using ConductorSharp.Engine.Util;
+using ConductorSharp.Engine.Util.Builders;
+
+namespace ConductorSharp.Engine.Builders
+{
+    /// <summary>
+    /// Extension methods to add a DO_WHILE loop with multiple inner tasks, based on BaseTaskBuilder.
+    /// </summary>
+    public static class DoWhileTaskExtensions
+    {
+        /// <summary>
+        /// Adds a DO_WHILE loop to the workflow definition.
+        /// </summary>
+        /// <typeparam name="TWorkflow">Workflow type</typeparam>
+        /// <param name="builder">Parent sequence builder</param>
+        /// <param name="reference">Expression selecting the workflow property holding the loop's reference name</param>
+        /// <param name="input">Expression creating the input</param>
+        /// <param name="configureBody">Delegate to add tasks inside the loop</param>
+        public static ITaskOptionsBuilder AddTask<TWorkflow>(
+            this ITaskSequenceBuilder<TWorkflow> builder,
+            Expression<Func<TWorkflow, DoWhileTaskModel>> reference,
+            Expression<Func<TWorkflow, DoWhileInput>> input,
+            Action<ITaskSequenceBuilder<TWorkflow>> configureBody
+        )
+            where TWorkflow : ITypedWorkflow
+        {
+            // Extract expressions
+            var taskBuilder = new DoWhileTaskBuilder<TWorkflow>(reference.Body, input.Body, builder.BuildConfiguration);
+            // Register it with the outer sequence
+            builder.AddTaskBuilderToSequence(taskBuilder);
+            // Allow the caller to configure inner loop body tasks
+            configureBody(taskBuilder);
+            return taskBuilder;
+        }
+    }
+
+    /// <summary>
+    /// Builder for the DO_WHILE task, extending BaseTaskBuilder for consistent patterns.
+    /// </summary>
+    internal sealed class DoWhileTaskBuilder<TWorkflow> : BaseTaskBuilder<DoWhileInput, NoOutput>, ITaskSequenceBuilder<TWorkflow>
+        where TWorkflow : ITypedWorkflow
+    {
+        private readonly DoWhileInput _doWhileInput;
+        private readonly List<WorkflowTask> _innerTasks = new();
+        public BuildContext BuildContext { get; } = new();
+        public BuildConfiguration BuildConfiguration { get; }
+        public WorkflowBuildItemRegistry WorkflowBuildRegistry { get; } = new();
+        public IEnumerable<ConfigurationProperty> ConfigurationProperties { get; } = new List<ConfigurationProperty>();
+
+        /// <inheritdoc />
+        public DoWhileTaskBuilder(Expression taskExpression, Expression loopConditionExpression, BuildConfiguration buildConfiguration)
+            : base(taskExpression, loopConditionExpression, buildConfiguration)
+        {
+            BuildConfiguration = buildConfiguration;
+            // Compile the JS condition string once
+            _doWhileInput = Expression.Lambda<Func<DoWhileInput>>(loopConditionExpression).Compile().Invoke();
+        }
+
+        /// <inheritdoc/>
+        public override WorkflowTask[] Build()
+        {
+            var refName = _taskRefferenceName;
+
+            if (_innerTasks.Any(t => t.WorkflowTaskType == WorkflowTaskType.DO_WHILE))
+            {
+                throw new InvalidOperationException("Nested DO_WHILE tasks are not allowed.");
+            }
+
+            var loopTask = new WorkflowTask
+            {
+                Name = refName,
+                TaskReferenceName = refName,
+                WorkflowTaskType = WorkflowTaskType.DO_WHILE,
+                Type = nameof(WorkflowTaskType.DO_WHILE),
+                InputParameters = new Dictionary<string, object>(),
+                LoopCondition = _doWhileInput.LoopCondition,
+                LoopOver = _innerTasks,
+            };
+            return [loopTask];
+        }
+
+        public void AddTaskBuilderToSequence(ITaskBuilder builder)
+        {
+            foreach (var task in builder.Build())
+            {
+                _innerTasks.Add(task);
+            }
+        }
+    }
+}

--- a/src/ConductorSharp.Engine/Model/DoWhileTaskModel.cs
+++ b/src/ConductorSharp.Engine/Model/DoWhileTaskModel.cs
@@ -1,0 +1,23 @@
+﻿using ConductorSharp.Engine.Builders;
+using MediatR;
+
+namespace ConductorSharp.Engine.Model
+{
+    /// <summary>
+    /// Input for configuration of the DO_WHILE task.
+    /// </summary>
+    public class DoWhileInput : IRequest<NoOutput>, IWorkflowInput
+    {
+        /// <summary>
+        /// Condition of the loop in JavaScript format.
+        /// Example: "$.do_while_ref['' + $.do_while_ref.iteration].number_adder_sub_workflow.success == false"
+        /// To access the latest iteration, use the following syntax: TaskRef.iteration
+        /// </summary>
+        public string LoopCondition { get; set; }
+    }
+
+    /// <summary>
+    /// Task Model to reference the do while task in the workflow builders
+    /// </summary>
+    public class DoWhileTaskModel : TaskModel<DoWhileInput, NoOutput> { }
+}

--- a/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
+++ b/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
@@ -42,6 +42,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Samples\Workflows\DictionaryInitializationWorkflow.json" />
+    <EmbeddedResource Include="Samples\Workflows\DoWhileTask.json" />
     <EmbeddedResource Include="Samples\Workflows\FormatterWorkflow.json" />
     <EmbeddedResource Include="Samples\Workflows\HumanTaskWorkflow.json" />
     <EmbeddedResource Include="Samples\Workflows\ListInitializationWorkflow.json" />

--- a/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
@@ -167,6 +167,15 @@ namespace ConductorSharp.Engine.Tests.Integration
         }
 
         [Fact]
+        public void BuilderReturnsCorrectDefinitionDoWhileTask()
+        {
+            var definition = GetDefinitionFromWorkflow<DoWhileTask>();
+            var expectedDefinition = EmbeddedFileHelper.GetLinesFromEmbeddedFile("~/Samples/Workflows/DoWhileTask.json");
+
+            Assert.Equal(expectedDefinition, definition);
+        }
+
+        [Fact]
         public void BuilderReturnsCorrectDefinitionSwitchTask()
         {
             var definition = GetDefinitionFromWorkflow<SwitchTask>();

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/DoWhileTask.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/DoWhileTask.cs
@@ -1,0 +1,27 @@
+﻿namespace ConductorSharp.Engine.Tests.Samples.Workflows
+{
+    public sealed class DoWhileTaskInput : WorkflowInput<DoWhileTaskOutput> { }
+
+    public sealed class DoWhileTaskOutput : WorkflowOutput { }
+
+    public sealed class DoWhileTask : Workflow<DoWhileTask, DoWhileTaskInput, DoWhileTaskOutput>
+    {
+        public DoWhileTaskModel DoWhile { get; set; }
+        public CustomerGetV1 GetCustomer { get; set; }
+
+        public DoWhileTask(WorkflowDefinitionBuilder<DoWhileTask, DoWhileTaskInput, DoWhileTaskOutput> builder)
+            : base(builder) { }
+
+        public override void BuildDefinition()
+        {
+            _builder.AddTask(
+                wf => wf.DoWhile,
+                wf => new() { LoopCondition = "$.do_while.iteration < 3" },
+                builder =>
+                {
+                    builder.AddTask(wf => wf.GetCustomer, wf => new CustomerGetV1Input() { CustomerId = "CUSTOMER-1" });
+                }
+            );
+        }
+    }
+}

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/DoWhileTask.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/DoWhileTask.json
@@ -1,0 +1,30 @@
+{
+  "name": "do_while_task",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "do_while",
+      "taskReferenceName": "do_while",
+      "inputParameters": {},
+      "type": "DO_WHILE",
+      "loopCondition": "$.do_while.iteration < 3",
+      "loopOver": [
+        {
+          "name": "CUSTOMER_get",
+          "taskReferenceName": "get_customer",
+          "inputParameters": {
+            "customer_id": "CUSTOMER-1"
+          },
+          "type": "SIMPLE",
+          "optional": false,
+          "workflowTaskType": "SIMPLE"
+        }
+      ],
+      "workflowTaskType": "DO_WHILE"
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {},
+  "schemaVersion": 2,
+  "timeoutSeconds": 0
+}

--- a/test/ConductorSharp.Engine.Tests/Util/EmbeddedFileHelper.cs
+++ b/test/ConductorSharp.Engine.Tests/Util/EmbeddedFileHelper.cs
@@ -1,9 +1,9 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.IO;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace ConductorSharp.Engine.Tests.Util
 {
@@ -43,7 +43,7 @@ namespace ConductorSharp.Engine.Tests.Util
 
             var contents = ReadAssemblyFile(typeof(EmbeddedFileHelper).Assembly, fileName);
 
-            return contents;
+            return contents.Replace("\r\n", "\n");
         }
 
         public static Task<T> GetObjectFromEmbeddedFileAsync<T>(string fileName, params (string Key, object Value)[] templateParams) =>


### PR DESCRIPTION
This PR introduces a builder that enables adding `DO_WHILE ` tasks to workflow definitions, in line with the official Conductor documentation:
🔗 https://conductor-oss.github.io/conductor/documentation/configuration/workflowdef/operators/do-while-task.html

Highlights:

- Adds a DoWhileTaskBuilder and AddTask extension for clean integration into existing workflow definitions.
- Supports loop conditions
- Supports fluent configuration of inner tasks via standard builder patterns.
- Includes a safeguard that prevents nested DO_WHILE blocks, which are not currently supported by Conductor OSS.

Additionally:

Included an optional fix to allow unit tests to run reliably on some Windows environments.

This builder enables structured looping and retry logic directly within workflows, using native Conductor features in a strongly-typed, maintainable way. Looking forward to your review! 🙌