### PR TITLE
Refactor code and add new ExecutionManager implementation (beta version)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist
 .env
 *.xmldocs.xml
 **/CONDUCTORSHARP_HEALTH.json
+.idea

--- a/src/ConductorSharp.Client/ConductorSharp.Client.csproj
+++ b/src/ConductorSharp.Client/ConductorSharp.Client.csproj
@@ -6,7 +6,7 @@
 		<Authors>Codaxy</Authors>
 		<Company>Codaxy</Company>
 		<PackageId>ConductorSharp.Client</PackageId>
-		<Version>3.5.0</Version>
+		<Version>3.6.0</Version>
 		<Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 		<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 		<PackageTags>netflix;conductor</PackageTags>

--- a/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
+++ b/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
@@ -6,7 +6,7 @@
     <Authors>Codaxy</Authors>
 	<Company>Codaxy</Company>
 	<PackageId>ConductorSharp.Engine</PackageId>
-	<Version>3.5.0</Version>
+	<Version>3.6.0</Version>
     <Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 	<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 	<PackageTags>netflix;conductor</PackageTags>

--- a/src/ConductorSharp.Engine/Extensions/ConductorSharpBuilder.cs
+++ b/src/ConductorSharp.Engine/Extensions/ConductorSharpBuilder.cs
@@ -43,7 +43,7 @@ namespace ConductorSharp.Engine.Extensions
 
             Builder.AddTransient<ModuleDeployment>();
 
-            Builder.AddSingleton<ExecutionManager>();
+            Builder.AddSingleton<IExecutionManager,ExecutionManager>();
 
             Builder.AddScoped<ConductorSharpExecutionContext>();
 
@@ -60,6 +60,12 @@ namespace ConductorSharp.Engine.Extensions
             return this;
         }
 
+        public IExecutionManagerBuilder UseBetaExecutionManager()
+        {
+            Builder.AddSingleton<IExecutionManager,TypePollSpreadingExecutionManager>();
+            return this;
+        }
+        
         public IExecutionManagerBuilder AddPipelines(Action<IPipelineBuilder> behaviorBuilder)
         {
             var pipelineBuilder = new PipelineBuilder(Builder);

--- a/src/ConductorSharp.Engine/Extensions/IExecutionManagerBuilder.cs
+++ b/src/ConductorSharp.Engine/Extensions/IExecutionManagerBuilder.cs
@@ -12,5 +12,6 @@ namespace ConductorSharp.Engine.Extensions
         IExecutionManagerBuilder SetHealthCheckService<T>()
             where T : IConductorSharpHealthService;
         IExecutionManagerBuilder UseConstantPollTimingStrategy();
+        IExecutionManagerBuilder UseBetaExecutionManager();
     }
 }

--- a/src/ConductorSharp.Engine/IExecutionManager.cs
+++ b/src/ConductorSharp.Engine/IExecutionManager.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace ConductorSharp.Engine;
 
-public interface IExecutionManager
+internal interface IExecutionManager
 {
     public Task StartAsync(CancellationToken cancellationToken);
 }

--- a/src/ConductorSharp.Engine/IExecutionManager.cs
+++ b/src/ConductorSharp.Engine/IExecutionManager.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ConductorSharp.Engine;
+
+public interface IExecutionManager
+{
+    public Task StartAsync(CancellationToken cancellationToken);
+}

--- a/src/ConductorSharp.Engine/Service/WorkflowEngineBackgroundService.cs
+++ b/src/ConductorSharp.Engine/Service/WorkflowEngineBackgroundService.cs
@@ -14,13 +14,13 @@ namespace ConductorSharp.Engine.Service
         IConductorSharpHealthService healthService,
         ILogger<WorkflowEngineBackgroundService> logger,
         IDeploymentService deploymentService,
-        ExecutionManager executionManager,
+        IExecutionManager executionManager,
         ModuleDeployment deployment
     ) : IHostedService, IDisposable
     {
         private readonly ILogger<WorkflowEngineBackgroundService> _logger = logger;
         private readonly IDeploymentService _deploymentService = deploymentService;
-        private readonly ExecutionManager _executionManager = executionManager;
+        private readonly IExecutionManager _executionManager = executionManager;
         private readonly ModuleDeployment _deployment = deployment;
         private readonly IConductorSharpHealthService _healthService = healthService;
         private Task _executingTask;

--- a/src/ConductorSharp.KafkaCancellationNotifier/ConductorSharp.KafkaCancellationNotifier.csproj
+++ b/src/ConductorSharp.KafkaCancellationNotifier/ConductorSharp.KafkaCancellationNotifier.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.5.0</Version>
+    <Version>3.6.0</Version>
     <Authors>Codaxy</Authors>
     <Company>Codaxy</Company>
   </PropertyGroup>

--- a/src/ConductorSharp.Patterns/ConductorSharp.Patterns.csproj
+++ b/src/ConductorSharp.Patterns/ConductorSharp.Patterns.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Codaxy</Authors>
     <Company>Codaxy</Company>
-    <Version>3.5.0</Version>
+    <Version>3.6.0</Version>
   </PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
There is an issue with polling - when there are multiple instances of the same task scheduled, they are polled one at a time, with delays in between. This PR adds an `IExecutionManager` interface (previously there was only the class `ExecutionManager`) to allow for registering alternate implementations. The PR also adds one such implementation, one which handles the issue of multiple polls of the same task type. We would not like to force this upon users for now, instead an extension method can be used to utilize it: 

```csharp
.AddExecutionManager(...)
.UseBetaExecutionManager();
```