### PR TITLE
CxODEV-1884: carry a diagnostic message on the structured_error contract

### DIFF
--- a/src/ConductorSharp.Client/ConductorSharp.Client.csproj
+++ b/src/ConductorSharp.Client/ConductorSharp.Client.csproj
@@ -6,7 +6,7 @@
 		<Authors>Codaxy</Authors>
 		<Company>Codaxy</Company>
 		<PackageId>ConductorSharp.Client</PackageId>
-		<Version>4.1.0</Version>
+		<Version>4.2.0</Version>
 		<Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 		<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 		<PackageTags>netflix;conductor</PackageTags>

--- a/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
+++ b/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
@@ -6,7 +6,7 @@
     <Authors>Codaxy</Authors>
 	<Company>Codaxy</Company>
 	<PackageId>ConductorSharp.Engine</PackageId>
-	<Version>4.1.0</Version>
+	<Version>4.2.0</Version>
     <Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 	<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 	<PackageTags>netflix;conductor</PackageTags>

--- a/src/ConductorSharp.Engine/Exceptions/StructuredErrorException.cs
+++ b/src/ConductorSharp.Engine/Exceptions/StructuredErrorException.cs
@@ -5,17 +5,22 @@ namespace ConductorSharp.Engine.Exceptions
     /// <summary>
     /// Thrown by a worker to attach a structured, sanitized error classification to the failed task's output.
     /// When caught by the execution manager, the <see cref="Code"/>/<see cref="Reason"/>/<see cref="ReferenceError"/>
-    /// are serialized under the <c>structured_error</c> output key (see
+    /// and the diagnostic message are serialized under the <c>structured_error</c> output key (see
     /// <see cref="ConductorSharp.Engine.Util.StructuredErrorSerializer"/>), in addition to the plain
     /// <c>error_message</c>, so downstream consumers can read a stable classification without parsing free-text
     /// reasons. Plain exceptions are unaffected and keep producing only <c>error_message</c>.
     /// </summary>
+    /// <remarks>
+    /// There is deliberately no <c>Message</c> property here: the diagnostic message is carried by the inherited
+    /// <see cref="Exception.Message"/>, which the message-taking constructors set. When no message is supplied it
+    /// falls back to <see cref="Reason"/>, matching the behaviour of the original constructors.
+    /// </remarks>
     public class StructuredErrorException : Exception
     {
         /// <summary>Stable, opaque classification code. Consumers map this to a failure response.</summary>
         public string Code { get; }
 
-        /// <summary>Human-readable, sanitized reason. Safe to surface across a layer boundary.</summary>
+        /// <summary>Short, stable, sanitized reason. Safe to surface across a layer boundary.</summary>
         public string Reason { get; }
 
         /// <summary>Optional URI pointing at the entity where the failure originated (drill-down link).</summary>
@@ -31,6 +36,36 @@ namespace ConductorSharp.Engine.Exceptions
 
         public StructuredErrorException(string code, string reason, string referenceError, Exception innerException)
             : base(reason, innerException)
+        {
+            Code = code;
+            Reason = reason;
+            ReferenceError = referenceError;
+        }
+
+        /// <summary>
+        /// Declares a diagnostic <paramref name="message"/> distinct from the short, stable
+        /// <paramref name="reason"/>. Pass <c>null</c> for <paramref name="message"/> to fall back to the reason,
+        /// and <c>null</c> for <paramref name="referenceError"/> when there is no entity to drill down into.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="message"/> trails <paramref name="referenceError"/> rather than following
+        /// <paramref name="reason"/> on purpose. Overload resolution cannot choose between
+        /// this constructor and the <see cref="Exception"/> one when the fourth argument is an untyped <c>null</c>,
+        /// so the nullable parameter is placed third, where it is typed the same either way. The only call this
+        /// leaves ambiguous is <c>(code, reason, referenceError, null)</c> — a declared-but-null inner exception,
+        /// which the three-argument constructor already expresses. Disambiguate with a named argument if needed.
+        /// </remarks>
+        public StructuredErrorException(string code, string reason, string referenceError, string message)
+            : base(message ?? reason)
+        {
+            Code = code;
+            Reason = reason;
+            ReferenceError = referenceError;
+        }
+
+        /// <inheritdoc cref="StructuredErrorException(string, string, string, string)"/>
+        public StructuredErrorException(string code, string reason, string referenceError, string message, Exception innerException)
+            : base(message ?? reason, innerException)
         {
             Code = code;
             Reason = reason;

--- a/src/ConductorSharp.Engine/ExecutionManager.cs
+++ b/src/ConductorSharp.Engine/ExecutionManager.cs
@@ -247,19 +247,9 @@ namespace ConductorSharp.Engine
                     pollResponse.WorkflowInstanceId
                 );
 
-                var errorMessage = new ErrorOutput { ErrorMessage = exception.Message };
-
                 // A worker may throw a StructuredErrorException to attach a sanitized, stable classification to the
                 // failed task's output. Plain exceptions keep producing only error_message, preserving backward compatibility.
-                if (exception is StructuredErrorException structuredException)
-                {
-                    errorMessage.StructuredError = new StructuredError
-                    {
-                        Code = structuredException.Code,
-                        Reason = structuredException.Reason,
-                        ReferenceError = structuredException.ReferenceError
-                    };
-                }
+                var errorMessage = new ErrorOutput { ErrorMessage = exception.Message, StructuredError = StructuredError.FromException(exception) };
 
                 // TODO: We should verify that this is alright, it is possible that when executed concurrently,
                 // the updates caused by LogAsync will be discarded because the call of UpdateAsync(TaskResult...)

--- a/src/ConductorSharp.Engine/Model/StructuredError.cs
+++ b/src/ConductorSharp.Engine/Model/StructuredError.cs
@@ -1,3 +1,6 @@
+using System;
+using ConductorSharp.Engine.Exceptions;
+
 namespace ConductorSharp.Engine.Model
 {
     /// <summary>
@@ -12,13 +15,43 @@ namespace ConductorSharp.Engine.Model
         /// <summary>Stable, opaque classification code (e.g. an implementation-defined code, or <c>UNCLASSIFIED</c>).</summary>
         public string Code { get; set; }
 
-        /// <summary>Human-readable, sanitized reason.</summary>
+        /// <summary>Short, stable, sanitized reason. Consumers may key off this text, so keep it terse.</summary>
         public string Reason { get; set; }
+
+        /// <summary>
+        /// Optional diagnostic detail, longer and more specific than <see cref="Reason"/> — the explanation an
+        /// operator needs, kept out of <see cref="Reason"/> so that stays short and stable. Null when the producer
+        /// supplied nothing distinct from the reason, in which case it is omitted from serialized output
+        /// (NullValueHandling.Ignore) and the payload is unchanged from before this field existed.
+        /// </summary>
+        public string Message { get; set; }
 
         /// <summary>Optional URI pointing at the entity where the failure originated (drill-down link).</summary>
         public string ReferenceError { get; set; }
 
         /// <summary>Payload shape version marker. Defaults to <see cref="CurrentVersion"/>.</summary>
         public int Version { get; set; } = CurrentVersion;
+
+        /// <summary>
+        /// Maps a thrown exception onto the payload, returning <c>null</c> for anything that is not a
+        /// <see cref="StructuredErrorException"/> so plain exceptions keep producing only <c>error_message</c>.
+        /// This is the single exception-to-payload mapping: both execution managers and the contract tests call it,
+        /// so the two poll strategies cannot drift apart as the shape evolves.
+        /// </summary>
+        public static StructuredError FromException(Exception exception)
+        {
+            if (exception is not StructuredErrorException structuredException)
+                return null;
+
+            return new StructuredError
+            {
+                Code = structuredException.Code,
+                Reason = structuredException.Reason,
+                // Exception.Message falls back to Reason when the thrower supplied no distinct detail, so only
+                // carry it when it actually adds something. Existing call sites keep their exact payload.
+                Message = structuredException.Message == structuredException.Reason ? null : structuredException.Message,
+                ReferenceError = structuredException.ReferenceError
+            };
+        }
     }
 }

--- a/src/ConductorSharp.Engine/TypePollSpreadingExecutionManager.cs
+++ b/src/ConductorSharp.Engine/TypePollSpreadingExecutionManager.cs
@@ -256,19 +256,9 @@ namespace ConductorSharp.Engine
                     pollResponse.WorkflowInstanceId
                 );
 
-                var errorMessage = new ErrorOutput { ErrorMessage = exception.Message };
-
                 // A worker may throw a StructuredErrorException to attach a sanitized, stable classification to the
                 // failed task's output. Plain exceptions keep producing only error_message, preserving backward compatibility.
-                if (exception is StructuredErrorException structuredException)
-                {
-                    errorMessage.StructuredError = new StructuredError
-                    {
-                        Code = structuredException.Code,
-                        Reason = structuredException.Reason,
-                        ReferenceError = structuredException.ReferenceError
-                    };
-                }
+                var errorMessage = new ErrorOutput { ErrorMessage = exception.Message, StructuredError = StructuredError.FromException(exception) };
 
                 // TODO: We should verify that this is alright, it is possible that when executed concurrently,
                 // the updates caused by LogAsync will be discarded because the call of UpdateAsync(TaskResult...)

--- a/src/ConductorSharp.KafkaCancellationNotifier/ConductorSharp.KafkaCancellationNotifier.csproj
+++ b/src/ConductorSharp.KafkaCancellationNotifier/ConductorSharp.KafkaCancellationNotifier.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>4.1.0</Version>
+    <Version>4.2.0</Version>
     <Authors>Codaxy</Authors>
     <Company>Codaxy</Company>
   </PropertyGroup>

--- a/src/ConductorSharp.Patterns/ConductorSharp.Patterns.csproj
+++ b/src/ConductorSharp.Patterns/ConductorSharp.Patterns.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Codaxy</Authors>
     <Company>Codaxy</Company>
-    <Version>4.1.0</Version>
+    <Version>4.2.0</Version>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/src/ConductorSharp.Toolkit/ConductorSharp.Toolkit.csproj
+++ b/src/ConductorSharp.Toolkit/ConductorSharp.Toolkit.csproj
@@ -7,7 +7,7 @@
     <Nullable>disable</Nullable>
 	<PackAsTool>true</PackAsTool>
 	<ToolCommandName>dotnet-conductorsharp</ToolCommandName>
-	<Version>4.1.0</Version>
+	<Version>4.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/ConductorSharp.Engine.Tests/Unit/StructuredErrorTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Unit/StructuredErrorTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using ConductorSharp.Client;
 using ConductorSharp.Client.Util;
 using ConductorSharp.Engine.Exceptions;
@@ -12,40 +13,33 @@ namespace ConductorSharp.Engine.Tests.Unit
 {
     public class StructuredErrorTests
     {
-        // Mirrors the execution-manager catch block: builds the ErrorOutput (setting StructuredError for a
-        // StructuredErrorException) and serializes it. TryParse below asserts this output round-trips through the
-        // shared serializer, pinning the property-derived key/shape to StructuredErrorSerializer.OutputKey.
+        // Mirrors the execution-manager catch block. It calls StructuredError.FromException — the same mapping both
+        // ExecutionManager and TypePollSpreadingExecutionManager use — rather than reimplementing it, so a field
+        // added to the payload cannot pass here while being dropped by one of the managers.
         private static IDictionary<string, object> SerializeCatchOutput(System.Exception exception)
         {
-            var output = new ErrorOutput { ErrorMessage = exception.Message };
-
-            if (exception is StructuredErrorException structuredException)
-            {
-                output.StructuredError = new StructuredError
-                {
-                    Code = structuredException.Code,
-                    Reason = structuredException.Reason,
-                    ReferenceError = structuredException.ReferenceError
-                };
-            }
+            var output = new ErrorOutput { ErrorMessage = exception.Message, StructuredError = StructuredError.FromException(exception) };
 
             return SerializationHelper.ObjectToDictionary(output, ConductorConstants.IoJsonSerializerSettings);
         }
 
+        private static JToken StructuredErrorOf(IDictionary<string, object> dict) =>
+            JObject.Parse(JsonConvert.SerializeObject(dict))[StructuredErrorSerializer.OutputKey];
+
         [Fact]
         public void StructuredErrorException_produces_snake_case_structured_error()
         {
-            var exception = new StructuredErrorException("RESOURCE_UNAVAILABLE", "No port available", "https://rom/resourceOrder/42");
+            var exception = new StructuredErrorException("RESOURCE_UNAVAILABLE", "No port available", "https://example.org/entity/42");
 
             var dict = SerializeCatchOutput(exception);
 
             Assert.True(dict.ContainsKey("error_message"));
             Assert.True(dict.ContainsKey(StructuredErrorSerializer.OutputKey));
 
-            var structured = JObject.Parse(JsonConvert.SerializeObject(dict))["structured_error"];
+            var structured = StructuredErrorOf(dict);
             Assert.Equal("RESOURCE_UNAVAILABLE", (string)structured["code"]);
             Assert.Equal("No port available", (string)structured["reason"]);
-            Assert.Equal("https://rom/resourceOrder/42", (string)structured["reference_error"]);
+            Assert.Equal("https://example.org/entity/42", (string)structured["reference_error"]);
             Assert.Equal(StructuredError.CurrentVersion, (int)structured["version"]);
         }
 
@@ -61,13 +55,87 @@ namespace ConductorSharp.Engine.Tests.Unit
         }
 
         [Fact]
+        public void Message_is_carried_under_snake_case_message_key()
+        {
+            var exception = new StructuredErrorException(
+                "VALIDATION_FAILED",
+                "Input field not recognized",
+                "https://example.org/entity/7",
+                "Field 'widget_id' is not present in schema 'default'."
+            );
+
+            var structured = StructuredErrorOf(SerializeCatchOutput(exception));
+
+            Assert.Equal("VALIDATION_FAILED", (string)structured["code"]);
+            Assert.Equal("Input field not recognized", (string)structured["reason"]);
+            Assert.Equal("Field 'widget_id' is not present in schema 'default'.", (string)structured["message"]);
+            Assert.Equal("https://example.org/entity/7", (string)structured["reference_error"]);
+        }
+
+        [Fact]
+        public void Message_reaches_error_message_and_reason_for_incompletion()
+        {
+            // error_message is set from Exception.Message, which the message-taking constructor overrides. The same
+            // value is what the execution manager sends as TaskResult.ReasonForIncompletion (the Conductor UI banner).
+            var exception = new StructuredErrorException("CODE", "Short reason", null, "Long diagnostic detail");
+
+            Assert.Equal("Long diagnostic detail", exception.Message);
+            Assert.Equal("Long diagnostic detail", (string)SerializeCatchOutput(exception)["error_message"]);
+        }
+
+        [Fact]
+        public void Message_is_omitted_when_no_message_was_supplied()
+        {
+            // Guards the backward-compatibility promise: pre-existing call sites must keep their exact payload.
+            var structured = StructuredErrorOf(
+                SerializeCatchOutput(new StructuredErrorException("CODE", "Short reason", "https://example.org/entity/1"))
+            );
+
+            Assert.Null(structured["message"]);
+            Assert.Equal(
+                new[] { "code", "reason", "reference_error", "version" },
+                ((JObject)structured).Properties().Select(p => p.Name).OrderBy(n => n)
+            );
+        }
+
+        [Fact]
+        public void Message_is_omitted_when_it_only_repeats_the_reason()
+        {
+            var exception = new StructuredErrorException("CODE", "Same text", null, "Same text");
+
+            Assert.Null(StructuredErrorOf(SerializeCatchOutput(exception))["message"]);
+        }
+
+        [Fact]
+        public void Message_survives_the_round_trip()
+        {
+            var dict = SerializeCatchOutput(
+                new StructuredErrorException("CODE", "Short reason", "https://example.org/entity/9", "Long diagnostic detail")
+            );
+
+            Assert.True(StructuredErrorSerializer.TryParse(dict, out var parsed));
+            Assert.Equal("CODE", parsed.Code);
+            Assert.Equal("Short reason", parsed.Reason);
+            Assert.Equal("Long diagnostic detail", parsed.Message);
+            Assert.Equal("https://example.org/entity/9", parsed.ReferenceError);
+        }
+
+        [Fact]
+        public void FromException_returns_null_for_a_plain_exception()
+        {
+            Assert.Null(StructuredError.FromException(new System.InvalidOperationException("boom")));
+        }
+
+        [Fact]
         public void RoundTrip_helper_output_is_parsed_back()
         {
+            // The signal-sender producer: no exception to catch, so the payload is rendered from the model directly.
             var error = new StructuredError
             {
                 Code = "UNCLASSIFIED",
                 Reason = "generic failure",
-                ReferenceError = "https://rom/resourceOrder/7"
+                Message = "downstream call failed: connection refused",
+                ReferenceError = "https://example.org/entity/7"
             };
 
             var outputData = StructuredErrorSerializer.ToOutputData(error);
@@ -75,6 +143,7 @@ namespace ConductorSharp.Engine.Tests.Unit
             Assert.True(StructuredErrorSerializer.TryParse(outputData, out var parsed));
             Assert.Equal(error.Code, parsed.Code);
             Assert.Equal(error.Reason, parsed.Reason);
+            Assert.Equal(error.Message, parsed.Message);
             Assert.Equal(error.ReferenceError, parsed.ReferenceError);
             Assert.Equal(error.Version, parsed.Version);
         }
@@ -119,6 +188,18 @@ namespace ConductorSharp.Engine.Tests.Unit
             var dict = new Dictionary<string, object>
             {
                 [StructuredErrorSerializer.OutputKey] = new Dictionary<string, object> { ["reason"] = "no code here" }
+            };
+
+            Assert.False(StructuredErrorSerializer.TryParse(dict, out _));
+        }
+
+        [Fact]
+        public void TryParse_tolerates_a_message_only_payload_by_degrading()
+        {
+            // A message without a code is still unstructured: the caller must fall back to the generic path.
+            var dict = new Dictionary<string, object>
+            {
+                [StructuredErrorSerializer.OutputKey] = new Dictionary<string, object> { ["message"] = "detail but no code" }
             };
 
             Assert.False(StructuredErrorSerializer.TryParse(dict, out _));


### PR DESCRIPTION
Closes CxODEV-1884.

## Problem

`StructuredErrorException` carries only `code` and `reason`. A worker that needs both a short, stable reason *and* a detailed explanation has nowhere to put the detail, so it gets folded into `reason`. That makes `reason` unusable as something consumers can match on, and leaves them with no separate diagnostic field.

## Change

`StructuredError` gains a `Message` property, populated from the exception.

**No `Message` property is added to the exception.** It already has one by virtue of being an `Exception`; the two new constructors set it through `base(message ?? reason)`. Adding a shadowing property would have split one name across two values selected by static type — the catch block reads `exception.Message` off the base type three lines from where it narrows to `StructuredErrorException`.

The detail has to live inside the `structured_error` subtree to be reachable at all. `TryParse` presence-checks that single key and deserializes nothing else, so consumers never see the sibling `error_message` when a structured payload is present.

## Parameter order

`message` trails `referenceError` rather than following `reason`. Overload resolution cannot choose between `(code, reason, referenceError, message)` and the existing `(code, reason, referenceError, innerException)` when the fourth argument is an untyped `null`:

```
error CS0121: The call is ambiguous between the following methods or properties:
'StructuredErrorException(string, string, string, Exception)' and
'StructuredErrorException(string, string, string, string)'
```

With `message` in third position that fires on `(code, reason, message, null)` — a message with no drill-down URI, which is the common case. Putting the nullable parameter third instead leaves only `(code, reason, referenceError, null)` ambiguous, an explicitly-null inner exception that the three-argument constructor already expresses. The reasoning is in the XML doc so it does not get "fixed" back.

## Backward compatibility

- The mapping emits `message` only when it differs from `reason`, so payloads from existing call sites are byte-identical.
- `NullValueHandling.Ignore` omits the key entirely when unset; `MissingMemberHandling` defaults to Ignore, so older consumers skip it without throwing.
- `CurrentVersion` stays at **1**. The field is purely additive, and bumping it would be harmful — `TryParse` ignores version but a consumer may not.
- Existing constructors are untouched; new ones are added as overloads. Editing the existing signature to insert `message` would have silently rebound every three-argument call site, sending the `referenceError` URI into `message` with no compiler complaint.

## Deduplication

Both execution managers carried a hand-copied exception-to-payload mapping, and the test *mirrored* it rather than calling it — so a new field could pass tests while being silently dropped by the type-poll path. Extracted into `StructuredError.FromException`; both managers and the tests now call it.

## Verification

62/62 tests pass (`dotnet test ConductorSharp.sln`), full solution builds with no new warnings. New coverage: `message` present under the snake_case key, omitted when unsupplied, omitted when it only repeats `reason`, surviving the `TryParse` round trip, reaching `error_message`/`ReasonForIncompletion`, and a `message`-only payload still degrading to the generic path.

## Related

Ships alongside #219, which backports the identical patch to the 3.8 line (3.8.1) for consumers pinned there. The five touched files were byte-identical between `v3.8.0` and `master`.

Note for signal-based producers: `StructuredErrorSerializer.ToOutputData` picks the new field up automatically, but callers that build the payload themselves must populate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)