### PR TITLE
CxODEV-1874: always carry message on structured_error (3.9.0 backport)

### DIFF
--- a/src/ConductorSharp.Client/ConductorSharp.Client.csproj
+++ b/src/ConductorSharp.Client/ConductorSharp.Client.csproj
@@ -6,7 +6,7 @@
 		<Authors>Codaxy</Authors>
 		<Company>Codaxy</Company>
 		<PackageId>ConductorSharp.Client</PackageId>
-		<Version>3.8.1</Version>
+		<Version>3.9.0</Version>
 		<Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 		<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 		<PackageTags>netflix;conductor</PackageTags>

--- a/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
+++ b/src/ConductorSharp.Engine/ConductorSharp.Engine.csproj
@@ -6,7 +6,7 @@
     <Authors>Codaxy</Authors>
 	<Company>Codaxy</Company>
 	<PackageId>ConductorSharp.Engine</PackageId>
-	<Version>3.8.1</Version>
+	<Version>3.9.0</Version>
     <Description>Client library for Netflix Conductor, with some additional quality of life features.</Description>
 	<RepositoryUrl>https://github.com/codaxy/conductor-sharp</RepositoryUrl>
 	<PackageTags>netflix;conductor</PackageTags>

--- a/src/ConductorSharp.Engine/Model/StructuredError.cs
+++ b/src/ConductorSharp.Engine/Model/StructuredError.cs
@@ -19,10 +19,11 @@ namespace ConductorSharp.Engine.Model
         public string Reason { get; set; }
 
         /// <summary>
-        /// Optional diagnostic detail, longer and more specific than <see cref="Reason"/> — the explanation an
-        /// operator needs, kept out of <see cref="Reason"/> so that stays short and stable. Null when the producer
-        /// supplied nothing distinct from the reason, in which case it is omitted from serialized output
-        /// (NullValueHandling.Ignore) and the payload is unchanged from before this field existed.
+        /// Diagnostic detail, longer and more specific than <see cref="Reason"/> — the explanation an
+        /// operator needs, kept out of <see cref="Reason"/> so that stays short and stable. Mirrors
+        /// <see cref="Exception.Message"/>, which falls back to the reason when the thrower supplied no
+        /// distinct detail — so on the exception path the field is always populated, and consumers can
+        /// read it without a reason fallback of their own.
         /// </summary>
         public string Message { get; set; }
 
@@ -47,9 +48,7 @@ namespace ConductorSharp.Engine.Model
             {
                 Code = structuredException.Code,
                 Reason = structuredException.Reason,
-                // Exception.Message falls back to Reason when the thrower supplied no distinct detail, so only
-                // carry it when it actually adds something. Existing call sites keep their exact payload.
-                Message = structuredException.Message == structuredException.Reason ? null : structuredException.Message,
+                Message = structuredException.Message,
                 ReferenceError = structuredException.ReferenceError
             };
         }

--- a/src/ConductorSharp.KafkaCancellationNotifier/ConductorSharp.KafkaCancellationNotifier.csproj
+++ b/src/ConductorSharp.KafkaCancellationNotifier/ConductorSharp.KafkaCancellationNotifier.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.8.1</Version>
+    <Version>3.9.0</Version>
     <Authors>Codaxy</Authors>
     <Company>Codaxy</Company>
   </PropertyGroup>

--- a/src/ConductorSharp.Patterns/ConductorSharp.Patterns.csproj
+++ b/src/ConductorSharp.Patterns/ConductorSharp.Patterns.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Codaxy</Authors>
     <Company>Codaxy</Company>
-    <Version>3.8.1</Version>
+    <Version>3.9.0</Version>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/test/ConductorSharp.Engine.Tests/Unit/StructuredErrorTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Unit/StructuredErrorTests.cs
@@ -84,26 +84,27 @@ namespace ConductorSharp.Engine.Tests.Unit
         }
 
         [Fact]
-        public void Message_is_omitted_when_no_message_was_supplied()
+        public void Message_falls_back_to_the_reason_when_no_message_was_supplied()
         {
-            // Guards the backward-compatibility promise: pre-existing call sites must keep their exact payload.
+            // Exception.Message defaults to the reason, and the payload always carries it — consumers read
+            // message without needing a reason fallback of their own.
             var structured = StructuredErrorOf(
                 SerializeCatchOutput(new StructuredErrorException("CODE", "Short reason", "https://example.org/entity/1"))
             );
 
-            Assert.Null(structured["message"]);
+            Assert.Equal("Short reason", (string)structured["message"]);
             Assert.Equal(
-                new[] { "code", "reason", "reference_error", "version" },
+                new[] { "code", "message", "reason", "reference_error", "version" },
                 ((JObject)structured).Properties().Select(p => p.Name).OrderBy(n => n)
             );
         }
 
         [Fact]
-        public void Message_is_omitted_when_it_only_repeats_the_reason()
+        public void Message_repeating_the_reason_is_still_carried()
         {
             var exception = new StructuredErrorException("CODE", "Same text", null, "Same text");
 
-            Assert.Null(StructuredErrorOf(SerializeCatchOutput(exception))["message"]);
+            Assert.Equal("Same text", (string)StructuredErrorOf(SerializeCatchOutput(exception))["message"]);
         }
 
         [Fact]


### PR DESCRIPTION
Backport of [#221](https://github.com/codaxy/conductor-sharp/pull/221) to the `v3` line — the source change is identical (cherry-pick).

`StructuredError.FromException` no longer suppresses `message` when it equals `reason` — the payload always mirrors `Exception.Message` (which falls back to the reason), so consumers read `message` directly without a reason fallback of their own.

**Payload impact:** throwers that supply no distinct message now emit `message` equal to `reason` (previously omitted). Additive-optional; `CurrentVersion` stays 1.

Versions bumped **3.8.1 → 3.9.0** for the four packages released on this line (Client, Engine, KafkaCancellationNotifier, Patterns); Toolkit stays at `3.0.1-beta3` as in 3.8.0/3.8.1. Tests 62/62 green.

SOE/ROE will pin 3.9.0 in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)