### PR TITLE
Add FORK_JOIN task support

### DIFF
--- a/src/ConductorSharp.Engine/Builders/ForkJoinTaskBuilder.cs
+++ b/src/ConductorSharp.Engine/Builders/ForkJoinTaskBuilder.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using ConductorSharp.Client.Generated;
+using ConductorSharp.Engine.Interface;
+using ConductorSharp.Engine.Model;
+using ConductorSharp.Engine.Util;
+using ConductorSharp.Engine.Util.Builders;
+
+namespace ConductorSharp.Engine.Builders
+{
+    public static class ForkJoinTaskExtensions
+    {
+        public static ITaskOptionsBuilder AddTask<TWorkflow>(
+            this ITaskSequenceBuilder<TWorkflow> builder,
+            Expression<Func<TWorkflow, ForkJoinTaskModel>> reference,
+            Expression<Func<TWorkflow, ForkJoinInput>> input,
+            params Action<ITaskSequenceBuilder<TWorkflow>>[] branches
+        )
+            where TWorkflow : ITypedWorkflow
+        {
+            if (branches == null || branches.Length == 0)
+                throw new InvalidOperationException("FORK_JOIN task requires at least one branch.");
+
+            var taskBuilder = new ForkJoinTaskBuilder<TWorkflow>(
+                reference.Body,
+                input.Body,
+                builder.BuildConfiguration,
+                builder.WorkflowBuildRegistry,
+                builder.ConfigurationProperties,
+                builder.BuildContext
+            );
+
+            foreach (var branch in branches)
+            {
+                taskBuilder.AddBranch();
+                branch(taskBuilder);
+            }
+
+            builder.AddTaskBuilderToSequence(taskBuilder);
+            return taskBuilder;
+        }
+    }
+
+    public class ForkJoinTaskBuilder<TWorkflow>(
+        Expression taskExpression,
+        Expression inputExpression,
+        BuildConfiguration buildConfiguration,
+        WorkflowBuildItemRegistry workflowBuildItemRegistry,
+        IEnumerable<ConfigurationProperty> configurationProperties,
+        BuildContext buildContext
+    ) : BaseTaskBuilder<ForkJoinInput, NoOutput>(taskExpression, inputExpression, buildConfiguration), ITaskSequenceBuilder<TWorkflow>
+        where TWorkflow : ITypedWorkflow
+    {
+        private readonly List<List<ITaskBuilder>> _branches = [];
+
+        public BuildContext BuildContext { get; } = buildContext;
+        public BuildConfiguration BuildConfiguration { get; } = buildConfiguration;
+        public WorkflowBuildItemRegistry WorkflowBuildRegistry { get; } = workflowBuildItemRegistry;
+        public IEnumerable<ConfigurationProperty> ConfigurationProperties { get; } = configurationProperties;
+
+        public void AddBranch() => _branches.Add([]);
+
+        public override WorkflowTask[] Build()
+        {
+            var forkTaskName = $"FORK_JOIN_{_taskRefferenceName}";
+            var joinTaskName = $"JOIN_{_taskRefferenceName}";
+
+            var builtBranches = _branches
+                .Select(branch => (ICollection<WorkflowTask>)branch.SelectMany(taskBuilder => taskBuilder.Build()).ToList())
+                .ToList();
+
+            for (var i = 0; i < builtBranches.Count; i++)
+            {
+                if (builtBranches[i].Count == 0)
+                    throw new InvalidOperationException($"FORK_JOIN branch {i} must contain at least one task.");
+            }
+
+            var joinOn = builtBranches.Select(branch => branch.Last().TaskReferenceName).ToList();
+
+            return
+            [
+                new()
+                {
+                    Name = forkTaskName,
+                    TaskReferenceName = forkTaskName,
+                    WorkflowTaskType = WorkflowTaskType.FORK_JOIN,
+                    Type = WorkflowTaskType.FORK_JOIN.ToString(),
+                    InputParameters = _inputParameters.ToObject<IDictionary<string, object>>(),
+                    ForkTasks = builtBranches,
+                },
+                new()
+                {
+                    Name = joinTaskName,
+                    TaskReferenceName = joinTaskName,
+                    WorkflowTaskType = WorkflowTaskType.JOIN,
+                    Type = WorkflowTaskType.JOIN.ToString(),
+                    JoinOn = joinOn,
+                },
+            ];
+        }
+
+        public void AddTaskBuilderToSequence(ITaskBuilder builder)
+        {
+            if (_branches.Count == 0)
+                throw new InvalidOperationException("Cannot add a task to a FORK_JOIN branch before the branch has been started.");
+
+            _branches[^1].Add(builder);
+        }
+    }
+}

--- a/src/ConductorSharp.Engine/Model/ForkJoinTaskModel.cs
+++ b/src/ConductorSharp.Engine/Model/ForkJoinTaskModel.cs
@@ -1,0 +1,8 @@
+﻿using MediatR;
+
+namespace ConductorSharp.Engine.Model
+{
+    public class ForkJoinInput : IRequest<NoOutput> { }
+
+    public class ForkJoinTaskModel : TaskModel<ForkJoinInput, NoOutput> { }
+}

--- a/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
+++ b/test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Samples\Workflows\DictionaryInitializationWorkflow.json" />
     <EmbeddedResource Include="Samples\Workflows\DoWhileTask.json" />
+    <EmbeddedResource Include="Samples\Workflows\ForkJoinTask.json" />
     <EmbeddedResource Include="Samples\Workflows\FormatterWorkflow.json" />
     <EmbeddedResource Include="Samples\Workflows\HumanTaskWorkflow.json" />
     <EmbeddedResource Include="Samples\Workflows\ListInitializationWorkflow.json" />

--- a/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
+++ b/test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs
@@ -176,6 +176,27 @@ namespace ConductorSharp.Engine.Tests.Integration
         }
 
         [Fact]
+        public void BuilderReturnsCorrectDefinitionForkJoinTask()
+        {
+            var definition = GetDefinitionFromWorkflow<ForkJoinTask>();
+            var expectedDefinition = EmbeddedFileHelper.GetLinesFromEmbeddedFile("~/Samples/Workflows/ForkJoinTask.json");
+
+            Assert.Equal(expectedDefinition, definition);
+        }
+
+        [Fact]
+        public void BuilderThrowsInvalidOperationExceptionForForkJoinTaskWithoutBranches()
+        {
+            Assert.Throws<InvalidOperationException>(GetDefinitionFromWorkflow<EmptyForkJoinTask>);
+        }
+
+        [Fact]
+        public void BuilderThrowsInvalidOperationExceptionForForkJoinTaskWithEmptyBranch()
+        {
+            Assert.Throws<InvalidOperationException>(GetDefinitionFromWorkflow<EmptyBranchForkJoinTask>);
+        }
+
+        [Fact]
         public void BuilderReturnsCorrectDefinitionSwitchTask()
         {
             var definition = GetDefinitionFromWorkflow<SwitchTask>();

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/EmptyBranchForkJoinTask.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/EmptyBranchForkJoinTask.cs
@@ -1,0 +1,37 @@
+﻿using ConductorSharp.Client.Generated;
+
+namespace ConductorSharp.Engine.Tests.Samples.Workflows
+{
+    public sealed class EmptyBranchForkJoinTaskInput : WorkflowInput<EmptyBranchForkJoinTaskOutput> { }
+
+    public sealed class EmptyBranchForkJoinTaskOutput : WorkflowOutput { }
+
+    public sealed class EmptyBranchForkJoinTask : Workflow<EmptyBranchForkJoinTask, EmptyBranchForkJoinTaskInput, EmptyBranchForkJoinTaskOutput>
+    {
+        public ForkJoinTaskModel ForkJoin { get; set; }
+
+        public EmptyBranchForkJoinTask(
+            WorkflowDefinitionBuilder<EmptyBranchForkJoinTask, EmptyBranchForkJoinTaskInput, EmptyBranchForkJoinTaskOutput> builder
+        )
+            : base(builder) { }
+
+        public override void BuildDefinition()
+        {
+            _builder.AddTask(
+                wf => wf.ForkJoin,
+                wf => new(),
+                branch =>
+                    branch.AddTasks(
+                        new WorkflowTask
+                        {
+                            Name = "task_a1",
+                            TaskReferenceName = "task_a1",
+                            Type = WorkflowTaskType.SIMPLE.ToString(),
+                            WorkflowTaskType = WorkflowTaskType.SIMPLE,
+                        }
+                    ),
+                branch => { }
+            );
+        }
+    }
+}

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/EmptyForkJoinTask.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/EmptyForkJoinTask.cs
@@ -1,0 +1,19 @@
+﻿namespace ConductorSharp.Engine.Tests.Samples.Workflows
+{
+    public sealed class EmptyForkJoinTaskInput : WorkflowInput<EmptyForkJoinTaskOutput> { }
+
+    public sealed class EmptyForkJoinTaskOutput : WorkflowOutput { }
+
+    public sealed class EmptyForkJoinTask : Workflow<EmptyForkJoinTask, EmptyForkJoinTaskInput, EmptyForkJoinTaskOutput>
+    {
+        public ForkJoinTaskModel ForkJoin { get; set; }
+
+        public EmptyForkJoinTask(WorkflowDefinitionBuilder<EmptyForkJoinTask, EmptyForkJoinTaskInput, EmptyForkJoinTaskOutput> builder)
+            : base(builder) { }
+
+        public override void BuildDefinition()
+        {
+            _builder.AddTask(wf => wf.ForkJoin, wf => new());
+        }
+    }
+}

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/ForkJoinTask.cs
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/ForkJoinTask.cs
@@ -1,0 +1,38 @@
+﻿using ConductorSharp.Client.Generated;
+
+namespace ConductorSharp.Engine.Tests.Samples.Workflows
+{
+    public sealed class ForkJoinTaskInput : WorkflowInput<ForkJoinTaskOutput> { }
+
+    public sealed class ForkJoinTaskOutput : WorkflowOutput { }
+
+    public sealed class ForkJoinTask : Workflow<ForkJoinTask, ForkJoinTaskInput, ForkJoinTaskOutput>
+    {
+        public ForkJoinTaskModel ForkJoin { get; set; }
+
+        public ForkJoinTask(WorkflowDefinitionBuilder<ForkJoinTask, ForkJoinTaskInput, ForkJoinTaskOutput> builder)
+            : base(builder) { }
+
+        public override void BuildDefinition()
+        {
+            _builder.AddTask(
+                wf => wf.ForkJoin,
+                wf => new(),
+                // Branch A has two tasks, to verify branch task ordering and that the JOIN's
+                // joinOn resolves to the branch's last task ("task_a2"), not its first ("task_a1").
+                branch => branch.AddTasks(NewSimpleTask("task_a1"), NewSimpleTask("task_a2")),
+                // Branch B has a single task, to verify a simple one-task branch still works alongside a multi-task one.
+                branch => branch.AddTasks(NewSimpleTask("task_b1"))
+            );
+        }
+
+        private static WorkflowTask NewSimpleTask(string referenceName) =>
+            new()
+            {
+                Name = referenceName,
+                TaskReferenceName = referenceName,
+                Type = WorkflowTaskType.SIMPLE.ToString(),
+                WorkflowTaskType = WorkflowTaskType.SIMPLE,
+            };
+    }
+}

--- a/test/ConductorSharp.Engine.Tests/Samples/Workflows/ForkJoinTask.json
+++ b/test/ConductorSharp.Engine.Tests/Samples/Workflows/ForkJoinTask.json
@@ -1,0 +1,51 @@
+{
+  "name": "fork_join_task",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "FORK_JOIN_fork_join",
+      "taskReferenceName": "FORK_JOIN_fork_join",
+      "inputParameters": {},
+      "type": "FORK_JOIN",
+      "forkTasks": [
+        [
+          {
+            "name": "task_a1",
+            "taskReferenceName": "task_a1",
+            "type": "SIMPLE",
+            "workflowTaskType": "SIMPLE"
+          },
+          {
+            "name": "task_a2",
+            "taskReferenceName": "task_a2",
+            "type": "SIMPLE",
+            "workflowTaskType": "SIMPLE"
+          }
+        ],
+        [
+          {
+            "name": "task_b1",
+            "taskReferenceName": "task_b1",
+            "type": "SIMPLE",
+            "workflowTaskType": "SIMPLE"
+          }
+        ]
+      ],
+      "workflowTaskType": "FORK_JOIN"
+    },
+    {
+      "name": "JOIN_fork_join",
+      "taskReferenceName": "JOIN_fork_join",
+      "type": "JOIN",
+      "joinOn": [
+        "task_a2",
+        "task_b1"
+      ],
+      "workflowTaskType": "JOIN"
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {},
+  "schemaVersion": 2,
+  "timeoutSeconds": 0
+}


### PR DESCRIPTION
## Objective

Add support for Conductor's static `FORK_JOIN` task type. The engine already supported `FORK_JOIN_DYNAMIC` (runtime-determined branches), but had no builder/model for the build-time, fixed-branch `FORK_JOIN` — even though the client SDK already carries the enum values and `ForkTasks`/`JoinOn` fields needed for it (`Client/Generated/Models.cs`).

## Approach

- `Builders/ForkJoinTaskBuilder.cs` — `AddTask(reference, input, params branches)`, where each branch is an `Action<ITaskSequenceBuilder<TWorkflow>>`. Builds one `FORK_JOIN` task (`ForkTasks` = each branch's built tasks, in order) plus an auto-generated companion `JOIN` task (`JoinOn` = the *last* task reference of each branch) — mirroring how `DynamicForkJoinTaskBuilder` emits a fork+join pair, and reusing `SwitchTaskBuilder`'s pattern for collecting multiple sub-branches into one builder.
- `Model/ForkJoinTaskModel.cs` — `ForkJoinInput`/`ForkJoinTaskModel`, following the same `TaskModel<TInput, NoOutput>` shape as every other operator.
- Validates zero branches, and validates each branch has at least one task, both raising a clear `InvalidOperationException` rather than letting an empty branch reach a bare LINQ `Sequence contains no elements` exception (an actual gap found and fixed during review).
- Test fixtures follow the exact 6-file shape used by every prior "add an operator" PR (do-while #205, events #188, human task #111, wait task #110): sample workflow `.cs` + expected `.json` (captured from the real serializer output, not hand-written) + `csproj` `EmbeddedResource` entry + `[Fact]`s in `Integration/WorkflowBuilderTests.cs`.
- The happy-path fixture (`ForkJoinTask.cs`) deliberately gives one branch two tasks using synthetic, non-business-flavored `PassThroughTaskExtensions.AddTasks` calls, specifically so the test can distinguish "picks the branch's last task" from "picks its first task" for `joinOn` — a single-task-per-branch fixture can't tell those apart, since first and last are the same task.
- No `README.md`/`SKILL.md` changes — confirmed no prior operator-addition PR ever touches docs (they're handled in separate bulk-doc PRs), so this follows that same precedent.

## Modified files (8 files, +287)

- `src/ConductorSharp.Engine/Builders/ForkJoinTaskBuilder.cs` (new)
- `src/ConductorSharp.Engine/Model/ForkJoinTaskModel.cs` (new)
- `test/ConductorSharp.Engine.Tests/Samples/Workflows/ForkJoinTask.cs` + `.json` (new)
- `test/ConductorSharp.Engine.Tests/Samples/Workflows/EmptyForkJoinTask.cs` (new — zero-branches case)
- `test/ConductorSharp.Engine.Tests/Samples/Workflows/EmptyBranchForkJoinTask.cs` (new — empty-branch case)
- `test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj` (+1 `EmbeddedResource`)
- `test/ConductorSharp.Engine.Tests/Integration/WorkflowBuilderTests.cs` (+3 `[Fact]`s)

## Checks

- `dotnet test test/ConductorSharp.Engine.Tests/ConductorSharp.Engine.Tests.csproj` — **passed**, 73/73 (3 new: happy path, zero-branches exception, empty-branch exception).
- `dotnet build ConductorSharp.sln` — **passed**.
- `dotnet csharpier --check` on all changed files — **passed** (repo's enforced pre-commit formatter).
- No live-Conductor / runtime-execution test exists for this — confirmed none exists for *any* operator in this repo (no such test infrastructure here at all, for any task type), so this isn't a gap specific to this change.

## Risks

- The branch-declaration API (`params Action<ITaskSequenceBuilder<TWorkflow>>[] branches`) is a new design choice — no direct precedent existed for "one property reference → N parallel branches" prior to this PR (`FORK_JOIN_DYNAMIC` doesn't need one, since its branches are runtime data, not C# code).
- `JoinOn` is computed as each branch's *last built task's* reference name. This is standard Conductor convention, but only exercised end-to-end via generated JSON assertions here, not against a live Conductor server.
- This environment's local .NET SDK only has the 10.0 runtime installed, not net6.0 (the projects' target framework) — all checks above were run with `DOTNET_ROLL_FORWARD=LatestMajor` and `HUSKY=0` (to skip the `husky install` pre-build hook, which also needs net8.0). Worth confirming your CI/dev environment has net6.0 so neither workaround is needed there.

## Review focus

- The `ForkJoinTaskBuilder<TWorkflow>` branch-collection API in `ForkJoinTaskBuilder.cs` — is `params Action<ITaskSequenceBuilder<TWorkflow>>[] branches` the shape you'd want, or would you prefer something else?
- `Name`/`TaskReferenceName` are both set to the same prefixed string (`FORK_JOIN_<ref>`, `JOIN_<ref>`) on the two emitted tasks, matching `DynamicForkJoinTaskBuilder`'s existing convention for two-task-emission builders (single-task builders like `WaitTaskBuilder` instead leave `TaskReferenceName` unprefixed) — confirm this reasoning holds.

## Out of scope

- `FORK_JOIN_DYNAMIC`, `DO_WHILE`, `SWITCH`, and every other existing operator — untouched.
- The generated client (`Client/Generated/Models.cs`) — already had what was needed.
- `README.md`/`SKILL.md` documentation — deliberately excluded per the operator-addition precedent (see Approach).
